### PR TITLE
Changed to no color change on a HREF hover.

### DIFF
--- a/_input/assets/css/style.css
+++ b/_input/assets/css/style.css
@@ -79,6 +79,10 @@ html, body
 	font-weight: 100;
 }
 
+a:hover {
+	color: #007bff;
+}
+
 #header
 {
 	margin-bottom: 4rem;


### PR DESCRIPTION
Added a CSS rule for `a:hover` so that the color will stay the same on HREF hover, overriding Bootstrap's default hover behavior.

Issue #28