### PR TITLE
Changed the layout to center anchors in the middle of the screen

### DIFF
--- a/_input/assets/css/style.css
+++ b/_input/assets/css/style.css
@@ -4,289 +4,311 @@
 
 /* roboto-mono-100 - latin */
 @font-face {
-	font-family: 'Roboto Mono';
-	font-style: normal;
-	font-weight: 100;
-	src: url('../font/roboto-mono-v5-latin-100.eot'); /* IE9 Compat Modes */
-	src: local('Roboto Mono Thin'), local('RobotoMono-Thin'),
-	url('../font/roboto-mono-v5-latin-100.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-	url('../font/roboto-mono-v5-latin-100.woff2') format('woff2'), /* Super Modern Browsers */
-	url('../font/roboto-mono-v5-latin-100.woff') format('woff'), /* Modern Browsers */
-	url('../font/roboto-mono-v5-latin-100.ttf') format('truetype'), /* Safari, Android, iOS */
-	url('../font/roboto-mono-v5-latin-100.svg#RobotoMono') format('svg'); /* Legacy iOS */
+    font-family: "Roboto Mono";
+    font-style: normal;
+    font-weight: 100;
+    src: url("../font/roboto-mono-v5-latin-100.eot"); /* IE9 Compat Modes */
+    src: local("Roboto Mono Thin"), local("RobotoMono-Thin"),
+        url("../font/roboto-mono-v5-latin-100.eot?#iefix")
+            format("embedded-opentype"),
+        /* IE6-IE8 */ url("../font/roboto-mono-v5-latin-100.woff2")
+            format("woff2"),
+        /* Super Modern Browsers */ url("../font/roboto-mono-v5-latin-100.woff")
+            format("woff"),
+        /* Modern Browsers */ url("../font/roboto-mono-v5-latin-100.ttf")
+            format("truetype"),
+        /* Safari, Android, iOS */
+            url("../font/roboto-mono-v5-latin-100.svg#RobotoMono") format("svg"); /* Legacy iOS */
 }
 
-  /* roboto-mono-300 - latin */
-  @font-face {
-	font-family: 'Roboto Mono';
-	font-style: normal;
-	font-weight: 300;
-	src: url('../font/roboto-mono-v5-latin-300.eot'); /* IE9 Compat Modes */
-	src: local('Roboto Mono Light'), local('RobotoMono-Light'),
-	url('../font/roboto-mono-v5-latin-300.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-	url('../font/roboto-mono-v5-latin-300.woff2') format('woff2'), /* Super Modern Browsers */
-	url('../font/roboto-mono-v5-latin-300.woff') format('woff'), /* Modern Browsers */
-	url('../font/roboto-mono-v5-latin-300.ttf') format('truetype'), /* Safari, Android, iOS */
-	url('../font/roboto-mono-v5-latin-300.svg#RobotoMono') format('svg'); /* Legacy iOS */
+/* roboto-mono-300 - latin */
+@font-face {
+    font-family: "Roboto Mono";
+    font-style: normal;
+    font-weight: 300;
+    src: url("../font/roboto-mono-v5-latin-300.eot"); /* IE9 Compat Modes */
+    src: local("Roboto Mono Light"), local("RobotoMono-Light"),
+        url("../font/roboto-mono-v5-latin-300.eot?#iefix")
+            format("embedded-opentype"),
+        /* IE6-IE8 */ url("../font/roboto-mono-v5-latin-300.woff2")
+            format("woff2"),
+        /* Super Modern Browsers */ url("../font/roboto-mono-v5-latin-300.woff")
+            format("woff"),
+        /* Modern Browsers */ url("../font/roboto-mono-v5-latin-300.ttf")
+            format("truetype"),
+        /* Safari, Android, iOS */
+            url("../font/roboto-mono-v5-latin-300.svg#RobotoMono") format("svg"); /* Legacy iOS */
 }
 
-  /* roboto-mono-regular - latin */
-  @font-face {
-	font-family: 'Roboto Mono';
-	font-style: normal;
-	font-weight: 400;
-	src: url('../font/roboto-mono-v5-latin-regular.eot'); /* IE9 Compat Modes */
-	src: local('Roboto Mono'), local('RobotoMono-Regular'),
-	url('../font/roboto-mono-v5-latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-	url('../font/roboto-mono-v5-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
-	url('../font/roboto-mono-v5-latin-regular.woff') format('woff'), /* Modern Browsers */
-	url('../font/roboto-mono-v5-latin-regular.ttf') format('truetype'), /* Safari, Android, iOS */
-	url('../font/roboto-mono-v5-latin-regular.svg#RobotoMono') format('svg'); /* Legacy iOS */
+/* roboto-mono-regular - latin */
+@font-face {
+    font-family: "Roboto Mono";
+    font-style: normal;
+    font-weight: 400;
+    src: url("../font/roboto-mono-v5-latin-regular.eot"); /* IE9 Compat Modes */
+    src: local("Roboto Mono"), local("RobotoMono-Regular"),
+        url("../font/roboto-mono-v5-latin-regular.eot?#iefix")
+            format("embedded-opentype"),
+        /* IE6-IE8 */ url("../font/roboto-mono-v5-latin-regular.woff2")
+            format("woff2"),
+        /* Super Modern Browsers */
+            url("../font/roboto-mono-v5-latin-regular.woff") format("woff"),
+        /* Modern Browsers */ url("../font/roboto-mono-v5-latin-regular.ttf")
+            format("truetype"),
+        /* Safari, Android, iOS */
+            url("../font/roboto-mono-v5-latin-regular.svg#RobotoMono")
+            format("svg"); /* Legacy iOS */
 }
 
-  /* roboto-mono-500 - latin */
-  @font-face {
-	font-family: 'Roboto Mono';
-	font-style: normal;
-	font-weight: 500;
-	src: url('../font/roboto-mono-v5-latin-500.eot'); /* IE9 Compat Modes */
-	src: local('Roboto Mono Medium'), local('RobotoMono-Medium'),
-	url('../font/roboto-mono-v5-latin-500.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-	url('../font/roboto-mono-v5-latin-500.woff2') format('woff2'), /* Super Modern Browsers */
-	url('../font/roboto-mono-v5-latin-500.woff') format('woff'), /* Modern Browsers */
-	url('../font/roboto-mono-v5-latin-500.ttf') format('truetype'), /* Safari, Android, iOS */
-	url('../font/roboto-mono-v5-latin-500.svg#RobotoMono') format('svg'); /* Legacy iOS */
+/* roboto-mono-500 - latin */
+@font-face {
+    font-family: "Roboto Mono";
+    font-style: normal;
+    font-weight: 500;
+    src: url("../font/roboto-mono-v5-latin-500.eot"); /* IE9 Compat Modes */
+    src: local("Roboto Mono Medium"), local("RobotoMono-Medium"),
+        url("../font/roboto-mono-v5-latin-500.eot?#iefix")
+            format("embedded-opentype"),
+        /* IE6-IE8 */ url("../font/roboto-mono-v5-latin-500.woff2")
+            format("woff2"),
+        /* Super Modern Browsers */ url("../font/roboto-mono-v5-latin-500.woff")
+            format("woff"),
+        /* Modern Browsers */ url("../font/roboto-mono-v5-latin-500.ttf")
+            format("truetype"),
+        /* Safari, Android, iOS */
+            url("../font/roboto-mono-v5-latin-500.svg#RobotoMono") format("svg"); /* Legacy iOS */
 }
 
-  /* roboto-mono-700 - latin */
-  @font-face {
-	font-family: 'Roboto Mono';
-	font-style: normal;
-	font-weight: 700;
-	src: url('../font/roboto-mono-v5-latin-700.eot'); /* IE9 Compat Modes */
-	src: local('Roboto Mono Bold'), local('RobotoMono-Bold'),
-	url('../font/roboto-mono-v5-latin-700.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-	url('../font/roboto-mono-v5-latin-700.woff2') format('woff2'), /* Super Modern Browsers */
-	url('../font/roboto-mono-v5-latin-700.woff') format('woff'), /* Modern Browsers */
-	url('../font/roboto-mono-v5-latin-700.ttf') format('truetype'), /* Safari, Android, iOS */
-	url('../font/roboto-mono-v5-latin-700.svg#RobotoMono') format('svg'); /* Legacy iOS */
+/* roboto-mono-700 - latin */
+@font-face {
+    font-family: "Roboto Mono";
+    font-style: normal;
+    font-weight: 700;
+    src: url("../font/roboto-mono-v5-latin-700.eot"); /* IE9 Compat Modes */
+    src: local("Roboto Mono Bold"), local("RobotoMono-Bold"),
+        url("../font/roboto-mono-v5-latin-700.eot?#iefix")
+            format("embedded-opentype"),
+        /* IE6-IE8 */ url("../font/roboto-mono-v5-latin-700.woff2")
+            format("woff2"),
+        /* Super Modern Browsers */ url("../font/roboto-mono-v5-latin-700.woff")
+            format("woff"),
+        /* Modern Browsers */ url("../font/roboto-mono-v5-latin-700.ttf")
+            format("truetype"),
+        /* Safari, Android, iOS */
+            url("../font/roboto-mono-v5-latin-700.svg#RobotoMono") format("svg"); /* Legacy iOS */
 }
 
-html, body
-{
-	font-family: 'Roboto Mono', monospace;
-	padding-bottom: 3rem;
-	font-weight: 300;
+html,
+body {
+    font-family: "Roboto Mono", monospace;
+    padding-bottom: 3rem;
+    font-weight: 300;
 }
 
 a:hover {
-	color: #007bff;
+    color: #007bff;
 }
 
-#header
-{
-	margin-bottom: 4rem;
-	position: relative;
-	overflow: hidden;
+#header {
+    margin-bottom: 4rem;
+    position: relative;
+    overflow: hidden;
     padding-bottom: 24.675rem;
 }
 
 #menu-button {
-	font-size: 1.375rem;
-	color: #007bff;
+    font-size: 1.375rem;
+    color: #007bff;
 }
 
-.rounded-circle
-{
-	margin-bottom: 15px;
+.rounded-circle {
+    margin-bottom: 15px;
 }
 
 .lead {
-	font-weight: 300;
+    font-weight: 300;
 }
 
 .active-link {
-	font-weight: 100 !important;
+    font-weight: 100 !important;
 }
 
 .navbar-link {
-	font-weight: 300;
+    font-weight: 300;
 }
 
-.full-screen {
-	min-height: calc(100vh - 40px);
+.full-screen-container {
+    min-height: calc(100vh - 56px);
+}
+
+.full-height-row {
+    min-height: 100vh;
 }
 
 #home_header_logo {
-	max-width: 30rem;
+    max-width: 30rem;
 }
 
 .home-header-text {
-	font-size: 1.75rem;
+    font-size: 1.75rem;
 }
 
 /* Scrolling icon
 -------------------------------------------------- */
 
 #icon-scroll {
-	display: none;
+    display: none;
 }
 
 .icon-scroll-row {
-	height: 70px;
-	margin-bottom: 5vh;
+    height: 70px;
+    margin-bottom: 5vh;
 }
 
-.icon-scroll, .icon-scroll:before {
-	position: absolute;
-	left: 50%;
-	top: 0;
+.icon-scroll,
+.icon-scroll:before {
+    position: absolute;
+    left: 50%;
+    top: 0;
 }
 .icon-scroll {
-	width: 40px;
-	height: 70px;
-	margin-left: -20px;
-	box-shadow: inset 0 0 0 1px rgb(33, 37, 41);
-	border-radius: 25px;
+    width: 40px;
+    height: 70px;
+    margin-left: -20px;
+    box-shadow: inset 0 0 0 1px rgb(33, 37, 41);
+    border-radius: 25px;
 }
 
 .icon-scroll:before {
-	content: '';
-	width: 8px;
-	height: 8px;
-	background: rgb(33, 37, 41);
-	margin-left: -4px;
-	top: 8px;
-	border-radius: 4px;
-	-webkit-animation-duration: 1.5s;
-			animation-duration: 1.5s;
-	-webkit-animation-iteration-count: infinite;
-			animation-iteration-count: infinite;
-	-webkit-animation-name: scroll;
-			animation-name: scroll;
+    content: "";
+    width: 8px;
+    height: 8px;
+    background: rgb(33, 37, 41);
+    margin-left: -4px;
+    top: 8px;
+    border-radius: 4px;
+    -webkit-animation-duration: 1.5s;
+    animation-duration: 1.5s;
+    -webkit-animation-iteration-count: infinite;
+    animation-iteration-count: infinite;
+    -webkit-animation-name: scroll;
+    animation-name: scroll;
 }
 
 @-webkit-keyframes scroll {
-	0% {
-		opacity: 1;
-	}
-	100% {
-		opacity: 0;
-		-webkit-transform: translateY(46px);
-				transform: translateY(46px);
-	}
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+        -webkit-transform: translateY(46px);
+        transform: translateY(46px);
+    }
 }
 
 @keyframes scroll {
-	0% {
-		opacity: 1;
-	}
-	100% {
-		opacity: 0;
-		-webkit-transform: translateY(46px);
-				transform: translateY(46px);
-	}
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+        -webkit-transform: translateY(46px);
+        transform: translateY(46px);
+    }
 }
 
 /* MARKETING CONTENT
 -------------------------------------------------- */
 
 /* Center align the text within the three columns below the carousel */
-.marketing .col-lg-4
-{
-	margin-bottom: 1.5rem;
-	text-align: center;
+.marketing .col-lg-4 {
+    /* margin-bottom: 1.5rem; */
+    text-align: center;
 }
 
-.marketing h2
-{
-	font-weight: 400;
+.marketing h2 {
+    font-weight: 400;
 }
 
-.marketing .col-lg-4 p
-{
-	margin-right: .75rem;
-	margin-left: .75rem;
+.marketing .col-lg-4 p {
+    margin-right: 0.75rem;
+    margin-left: 0.75rem;
 }
 
 .hover-link-container a {
-	position: relative;
-	visibility: hidden;
-	margin: 0 -10px;
+    position: relative;
+    visibility: hidden;
+    margin: 0 -10px;
 }
 
 .hover-link-container:hover a {
-	visibility: visible;
+    visibility: visible;
 }
 
 /* Featurettes
 ------------------------- */
 
-.featurette-divider
-{
-	margin: 5rem 0; /* Space out the Bootstrap <hr> more */
-	border-top-color: #ffffff;
+.featurette-divider {
+    margin: 5rem 0; /* Space out the Bootstrap <hr> more */
+    border-top-color: #ffffff;
 }
 
-.footer-divider
-{
-	margin-top: 4em;
-	margin-bottom: 4em;
+.footer-divider {
+    margin-top: 4em;
+    margin-bottom: 4em;
 }
 
 .vr {
-	border-left: 1px solid rgb(226, 226, 226);
-	position: relative;
-	height: 9rem;
-	top: -70px;
+    border-left: 1px solid rgb(226, 226, 226);
+    position: relative;
+    height: 9rem;
+    top: -70px;
 }
 
 .site-map-text {
-	font-size: .55rem;
-	margin: 0 4rem;
+    font-size: 0.55rem;
+    margin: 0 4rem;
 }
 
 .site-map-link {
-	margin: 0 1rem;
-	line-height: .6rem;
+    margin: 0 1rem;
+    line-height: 0.6rem;
 }
 
 #badges {
-  height: 40px;
-  text-align: justify;
-  font-size: 0.1px; /* IE 9 & 10 don't like font-size: 0; */
-  padding-right: 4rem;
-  padding-left: 4rem;
-  width: 100%;
-  max-width: 30rem;
+    height: 40px;
+    text-align: justify;
+    font-size: 0.1px; /* IE 9 & 10 don't like font-size: 0; */
+    padding-right: 4rem;
+    padding-left: 4rem;
+    width: 100%;
+    max-width: 30rem;
 }
 #badges a {
-  width: 40px;
-  height: 40px;
-  display: inline-block;
+    width: 40px;
+    height: 40px;
+    display: inline-block;
 }
 
 #badges:after {
-  content: '';
-  width: 100%; /* Ensures there are at least 2 lines of text, so justification works */
-  display: inline-block;
+    content: "";
+    width: 100%; /* Ensures there are at least 2 lines of text, so justification works */
+    display: inline-block;
 }
 
 #copy {
-	margin-top: 40px;
+    margin-top: 40px;
 }
 
 #commit_id {
-	margin-top: 40px;
+    margin-top: 40px;
 }
 
-
 /* Thin out the marketing headings */
-.featurette-heading
-{
-	font-weight: 300;
-	line-height: 1;
-	letter-spacing: -.05rem;
+.featurette-heading {
+    font-weight: 300;
+    line-height: 1;
+    letter-spacing: -0.05rem;
 }
 
 /* Placeholder
@@ -322,7 +344,6 @@ a:hover {
     height: 100%;
 }
 
-
 /* OVERWRITES
 -------------------------------------------------- */
 
@@ -334,43 +355,37 @@ a:hover {
 }
 
 .grecaptcha-badge {
-	position: relative;
-	top: 15px;
-	left: 0;
+    position: relative;
+    top: 15px;
+    left: 0;
 }
 
 /* RESPONSIVE CSS
 -------------------------------------------------- */
 
-@media (min-width: 40em)
-{
-	/* Bump up size of carousel content */
-	.carousel-caption p
-	{
-		margin-bottom: 1.25rem;
-		font-size: 1.25rem;
-		line-height: 1.4;
-	}
+@media (min-width: 40em) {
+    /* Bump up size of carousel content */
+    .carousel-caption p {
+        margin-bottom: 1.25rem;
+        font-size: 1.25rem;
+        line-height: 1.4;
+    }
 
-	.featurette-heading
-	{
-		font-size: 50px;
-	}
+    .featurette-heading {
+        font-size: 50px;
+    }
 }
 
-@media (min-width: 62em)
-{
-	.featurette-heading
-	{
-		margin-top: 7rem;
-	}
-
+@media (min-width: 62em) {
+    .featurette-heading {
+        margin-top: 7rem;
+    }
 }
 
 @media (max-width: 75em) {
     .placeholder-masker {
         height: 20.675rem;
-	}
+    }
 }
 
 @media (max-width: 62em) {
@@ -380,18 +395,18 @@ a:hover {
 
     #header {
         padding-bottom: 15.675rem;
-	}
+    }
 
-	.footer-divider {
-		margin-top: 3em;
-		margin-bottom: 3em;
-	}
+    .footer-divider {
+        margin-top: 3em;
+        margin-bottom: 3em;
+    }
 }
 
 @media (max-width: 48em) {
-	#send {
-		width: 100%;
-	}
+    #send {
+        width: 100%;
+    }
 
     .placeholder-masker {
         height: 11.675rem;
@@ -399,33 +414,48 @@ a:hover {
 
     #header {
         padding-bottom: 32vw;
-	}
+    }
 
-	.featurette-divider {
-		margin-top: .5rem;
-		margin-bottom: .5rem;
-	}
+    .featurette-divider {
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
+    }
 
-	.home-header-text {
-		font-size: 1.25rem;
-	}
-
+    .home-header-text {
+        font-size: 1.25rem;
+    }
 }
 
-/* EXTRA SMALL DEVICES (PORTRAIT PHONES, LESS THAN 576px) */
+/* EXTRA SMALL DEVICES (PORTRAIT PHONES, LESS THAN 576PX) */
 @media (max-width: 575.98px) {
-	.navbar, .navbar-toggler {
-		padding-top: 0;
-	}
+    .navbar,
+    .navbar-toggler {
+        padding-top: 0;
+    }
+
+    .full-screen-container {
+        min-height: calc(100vh - 36px);
+    }
 }
 
-/* MEDIUM DEVICES (TABLETS, LESS THAN 992px) */
-@media (max-width: 991.98px) {
-	.navbar-nav {
-		flex-direction: column !important;
-		align-items: center;
-		padding-right: 0;
-		padding-top: .5rem;
-	}
+/* SMALL TO MEDIUM DEVICES (LANDSCAPE PHONES AND TABLETS, 576PX AND UP) */
+@media (min-width: 576px) and (max-width: 991.98px) {
+    .full-screen-container {
+        min-height: calc(100vh - 48px);
+    }
+}
 
+/* MEDIUM DEVICES (TABLETS, LESS THAN 992PX) */
+@media (max-width: 991.98px) {
+    .full-height-row {
+        margin-bottom: 2rem;
+        margin-top: 2rem;
+    }
+
+    .navbar-nav {
+        flex-direction: column !important;
+        align-items: center;
+        padding-right: 0;
+        padding-top: 0.5rem;
+    }
 }

--- a/_input/views/_frame.html
+++ b/_input/views/_frame.html
@@ -46,22 +46,22 @@
 	<body>
 
 		<header>
-            <nav class="navbar navbar-light navbar-expand-lg site-header sticky-top d-flex justify-content-end">
-                <button class="navbar-toggler mx-auto" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                    <span id="menu-button">Menu</span>
-                </button>
+			<nav class="navbar navbar-light navbar-expand-lg site-header sticky-top d-flex justify-content-end">
+				<button class="navbar-toggler mx-auto" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+					<span id="menu-button">Menu</span>
+				</button>
 
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <ul class="navbar-nav mr-auto container d-flex flex-column flex-md-row justify-content-between">
-                        <li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="/">Home</a> </li>
-                        <li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="about.html">About</a> </li>
-                        <li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="ideas.html">Ideas</a> </li>
-                        <li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="clients.html">Clients</a> </li>
-                        <li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="toolbox.html">Toolbox</a> </li>
-                        <li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="contact.html">Contact</a> </li>
-                    </ul>
-                </div>
-            </nav>
+				<div class="collapse navbar-collapse" id="navbarSupportedContent">
+					<ul class="navbar-nav mr-auto container d-flex flex-column flex-md-row justify-content-between">
+						<li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="/">Home</a> </li>
+						<li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="about.html">About</a> </li>
+						<li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="ideas.html">Ideas</a> </li>
+						<li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="clients.html">Clients</a> </li>
+						<li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="toolbox.html">Toolbox</a> </li>
+						<li class="nav-item"> <a class="navbar-link py-2 d-md-inline-block" href="contact.html">Contact</a> </li>
+					</ul>
+				</div>
+			</nav>
 		</header>
 
 		<main role="main">

--- a/_input/views/about.html
+++ b/_input/views/about.html
@@ -3,8 +3,8 @@
 		<source srcset="./assets/img/about/header@1x.jpg 1x, ./assets/img/about/header@2x.jpg 2x" />
 		<img class="featurette-image img-fluid mx-auto" src="./assets/img/about/header@1x.jpg" alt="{{ title }}" />
 		<div class="placeholder-masker">
-            <div class="placeholder-animated-background"></div>
-        </div>
+			<div class="placeholder-animated-background"></div>
+		</div>
 	</picture>
 </div>
 

--- a/_input/views/apps.html
+++ b/_input/views/apps.html
@@ -3,8 +3,8 @@
 		<source srcset="./assets/img/apps/header@1x.jpg 1x, ./assets/img/apps/header@2x.jpg 2x" />
 		<img class="featurette-image img-fluid mx-auto" src="./assets/img/apps/header@1x.jpg" alt="{{ title }}" />
 		<div class="placeholder-masker">
-            <div class="placeholder-animated-background"></div>
-        </div>
+			<div class="placeholder-animated-background"></div>
+		</div>
 	</picture>
 </div>
 

--- a/_input/views/clients.html
+++ b/_input/views/clients.html
@@ -3,8 +3,8 @@
 		<source srcset="./assets/img/clients/header@1x.jpg 1x, ./assets/img/clients/header@2x.jpg 2x" />
 		<img class="featurette-image img-fluid mx-auto" src="./assets/img/clients/header@1x.jpg" alt="{{ title }}" />
 		<div class="placeholder-masker">
-            <div class="placeholder-animated-background"></div>
-        </div>
+			<div class="placeholder-animated-background"></div>
+		</div>
 	</picture>
 </div>
 

--- a/_input/views/contact.html
+++ b/_input/views/contact.html
@@ -5,8 +5,8 @@
 		<source srcset="./assets/img/contact/header@1x.jpg 1x, ./assets/img/contact/header@2x.jpg 2x" />
 		<img class="featurette-image img-fluid mx-auto" src="./assets/img/contact/header@1x.jpg" alt="{{ title }}" />
 		<div class="placeholder-masker">
-            <div class="placeholder-animated-background"></div>
-        </div>
+			<div class="placeholder-animated-background"></div>
+		</div>
 	</picture>
 </div>
 

--- a/_input/views/error.html
+++ b/_input/views/error.html
@@ -1,10 +1,10 @@
-<div id="header" class="container">
+s<div id="header" class="container">
 	<picture>
 		<source srcset="./assets/img/error/header@1x.jpg 1x, ./assets/img/error/header@2x.jpg 2x" />
 		<img class="featurette-image img-fluid mx-auto" src="./assets/img/error/header@1x.jpg" alt="{{ title }}" />
 		<div class="placeholder-masker">
-            <div class="placeholder-animated-background"></div>
-        </div>
+			<div class="placeholder-animated-background"></div>
+		</div>
 	</picture>
 </div>
 

--- a/_input/views/home.html
+++ b/_input/views/home.html
@@ -1,187 +1,187 @@
 <div class="container full-screen-container d-flex flex-column justify-content-start justify-content-md-center">
-    <div class="row d-flex justify-content-center">
-        <div class="col-12 col-md-11 col-lg-8 d-flex flex-column justify-content-center mt-0 mt-sm-5" id="home_header">
-            <img class="mx-auto" src="./assets/img/_global/company_logo_rectangle.svg" id="home_header_logo" alt="logo" />
-            <p class="mt-3 text-center home-header-text">We build software with solid foundations to provide flexible
-                solutions
-                that are easily modified and extended.</p>
-        </div>
-    </div>
-    <div class="row d-flex position-relative icon-scroll-row">
-        <div class="icon-scroll" id="icon-scroll"></div>
-    </div>
+	<div class="row d-flex justify-content-center">
+		<div class="col-12 col-md-11 col-lg-8 d-flex flex-column justify-content-center mt-0 mt-sm-5" id="home_header">
+			<img class="mx-auto" src="./assets/img/_global/company_logo_rectangle.svg" id="home_header_logo" alt="logo" />
+			<p class="mt-3 text-center home-header-text">We build software with solid foundations to provide flexible
+				solutions
+				that are easily modified and extended.</p>
+		</div>
+	</div>
+	<div class="row d-flex position-relative icon-scroll-row">
+		<div class="icon-scroll" id="icon-scroll"></div>
+	</div>
 </div>
 
 <div class="container marketing">
 
-    <div class="row full-height-row d-flex align-items-center">
-        <div class="col-lg-4">
-            <picture class="rounded-circle">
-                <source srcset="./assets/img/home/circles/circle1@1x.jpg 1x, ./assets/img/home/circles/circle1@2x.jpg 2x" />
-                <img src="./assets/img/home/circles/circle1@1x.jpg" alt="We Can Manage" width="140" height="140" />
-            </picture>
-            <h2>We Can Manage</h2>
-            <p>100% — if you have an idea, but lack the technical experience required to run a software project, we can
-                help
-                you.</p>
-        </div>
-        <div class="col-lg-4">
-            <picture class="rounded-circle">
-                <source srcset="./assets/img/home/circles/circle2@1x.jpg 1x, ./assets/img/home/circles/circle2@2x.jpg 2x" />
-                <img src="./assets/img/home/circles/circle2@1x.jpg" alt="We Can Build" width="140" height="140" />
-            </picture>
-            <h2>We Can Build</h2>
-            <p>We sure can! Just describe your problem, and we'll come up with a clean architecture, write the
-                necessary code,
-                and make it work.</p>
-        </div>
-        <div class="col-lg-4">
-            <picture class="rounded-circle">
-                <source srcset="./assets/img/home/circles/circle3@1x.jpg 1x, ./assets/img/home/circles/circle3@2x.jpg 2x" />
-                <img src="./assets/img/home/circles/circle3@1x.jpg" alt="We Can Research" width="140" height="140" />
-            </picture>
-            <h2>We Can Research</h2>
-            <p>0x4447™ will find a way. Bring us your new and original idea, and we'll do the R&D for you. We'll come
-                up with a
-                solution.</p>
-        </div>
-    </div>
+	<div class="row full-height-row d-flex align-items-center">
+		<div class="col-lg-4">
+			<picture class="rounded-circle">
+				<source srcset="./assets/img/home/circles/circle1@1x.jpg 1x, ./assets/img/home/circles/circle1@2x.jpg 2x" />
+				<img src="./assets/img/home/circles/circle1@1x.jpg" alt="We Can Manage" width="140" height="140" />
+			</picture>
+			<h2>We Can Manage</h2>
+			<p>100% — if you have an idea, but lack the technical experience required to run a software project, we can
+				help
+				you.</p>
+		</div>
+		<div class="col-lg-4">
+			<picture class="rounded-circle">
+				<source srcset="./assets/img/home/circles/circle2@1x.jpg 1x, ./assets/img/home/circles/circle2@2x.jpg 2x" />
+				<img src="./assets/img/home/circles/circle2@1x.jpg" alt="We Can Build" width="140" height="140" />
+			</picture>
+			<h2>We Can Build</h2>
+			<p>We sure can! Just describe your problem, and we'll come up with a clean architecture, write the
+				necessary code,
+				and make it work.</p>
+		</div>
+		<div class="col-lg-4">
+			<picture class="rounded-circle">
+				<source srcset="./assets/img/home/circles/circle3@1x.jpg 1x, ./assets/img/home/circles/circle3@2x.jpg 2x" />
+				<img src="./assets/img/home/circles/circle3@1x.jpg" alt="We Can Research" width="140" height="140" />
+			</picture>
+			<h2>We Can Research</h2>
+			<p>0x4447™ will find a way. Bring us your new and original idea, and we'll do the R&D for you. We'll come
+				up with a
+				solution.</p>
+		</div>
+	</div>
 
-    <div class="row featurette full-height-row d-flex align-items-center" id="we_can_manage">
-        <div class="col-md-6 order-md-2 order-sm-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/home/squares/square1@1x.jpg 1x, ./assets/img/home/squares/square1@2x.jpg 2x">
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square1@1x.jpg" alt="We Can Manage">
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-1 order-sm-2">
-            <h2 class="featurette-heading hover-link-container">
-                We Can Manage
-                <a href="#we_can_manage">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">Collectively, 0x4447 has logged dozens of years of collective experience. We've worked in
-                different
-                capacities at a range of companies. That work included numerous projects, products, and more. Through
-                it all, we
-                learned how to bring out the best in people and how to organize and manage a project by building a
-                solid foundation
-                that allows for easy expansion, maintenance, and adaptation to the changing times.</p>
-        </div>
-    </div>
+	<div class="row featurette full-height-row d-flex align-items-center" id="we_can_manage">
+		<div class="col-md-6 order-md-2 order-sm-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/home/squares/square1@1x.jpg 1x, ./assets/img/home/squares/square1@2x.jpg 2x">
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square1@1x.jpg" alt="We Can Manage">
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-1 order-sm-2">
+			<h2 class="featurette-heading hover-link-container">
+				We Can Manage
+				<a href="#we_can_manage">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">Collectively, 0x4447 has logged dozens of years of collective experience. We've worked in
+				different
+				capacities at a range of companies. That work included numerous projects, products, and more. Through
+				it all, we
+				learned how to bring out the best in people and how to organize and manage a project by building a
+				solid foundation
+				that allows for easy expansion, maintenance, and adaptation to the changing times.</p>
+		</div>
+	</div>
 
-    <div class="row featurette full-height-row d-flex align-items-center" id="we_can_build">
-        <div class="col-md-6 order-md-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/home/squares/square2@1x.jpg 1x, ./assets/img/home/squares/square2@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square2@1x.jpg" alt="We Can Build" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-2">
-            <h2 class="featurette-heading hover-link-container">
-                We Can Build
-                <a href="#we_can_build">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">Over the years, we've built regular sites, created efficient back-end solutions, designed
-                and
-                implemented custom protocols, and designed systems that work effectively and serve our clients well.</p>
-            <p class="lead">We understand how computers work, and we're familiar with all of their components, so we're
-                able to
-                tell them to do whatever we want them to do. The only thing we can't do is break the laws of physics.</p>
-        </div>
-    </div>
+	<div class="row featurette full-height-row d-flex align-items-center" id="we_can_build">
+		<div class="col-md-6 order-md-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/home/squares/square2@1x.jpg 1x, ./assets/img/home/squares/square2@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square2@1x.jpg" alt="We Can Build" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-2">
+			<h2 class="featurette-heading hover-link-container">
+				We Can Build
+				<a href="#we_can_build">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">Over the years, we've built regular sites, created efficient back-end solutions, designed
+				and
+				implemented custom protocols, and designed systems that work effectively and serve our clients well.</p>
+			<p class="lead">We understand how computers work, and we're familiar with all of their components, so we're
+				able to
+				tell them to do whatever we want them to do. The only thing we can't do is break the laws of physics.</p>
+		</div>
+	</div>
 
-    <div class="row featurette full-height-row d-flex align-items-center" id="we_can_research">
-        <div class="col-md-6 order-md-2 order-sm-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/home/squares/square3@1x.jpg 1x, ./assets/img/home/squares/square3@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square3@1x.jpg" alt="We Can Research" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-1 order-sm-2">
-            <h2 class="featurette-heading hover-link-container">
-                We Can Research
-                <a href="#we_can_research">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">To stay competitive, you have to consistently create new features based on constant
-                research.</p>
-            <p class="lead">When it comes to R&D, you won't find a better company than 0x4447. We're always questioning
-                the
-                world, turning over every rock to see what's underneath, and unceasingly asking why. We're inquisitive
-                by design.</p>
-        </div>
-    </div>
+	<div class="row featurette full-height-row d-flex align-items-center" id="we_can_research">
+		<div class="col-md-6 order-md-2 order-sm-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/home/squares/square3@1x.jpg 1x, ./assets/img/home/squares/square3@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square3@1x.jpg" alt="We Can Research" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-1 order-sm-2">
+			<h2 class="featurette-heading hover-link-container">
+				We Can Research
+				<a href="#we_can_research">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">To stay competitive, you have to consistently create new features based on constant
+				research.</p>
+			<p class="lead">When it comes to R&D, you won't find a better company than 0x4447. We're always questioning
+				the
+				world, turning over every rock to see what's underneath, and unceasingly asking why. We're inquisitive
+				by design.</p>
+		</div>
+	</div>
 
-    <hr class="featurette-divider">
+	<hr class="featurette-divider">
 
-    <h1>The Next Step</h1>
+	<h1>The Next Step</h1>
 
-    <p>Now that you know a little bit more about what we can do, check out <a href="about.html">why we do what we do</a>.</p>
+	<p>Now that you know a little bit more about what we can do, check out <a href="about.html">why we do what we do</a>.</p>
 
 </div>
 
 <script>
 
-    //
-    //	Shows a `div` containing a scrolling icon for 2 seconds.
-    //
-    function show_icon_for_two_seconds() {
+	//
+	//	Shows a `div` containing a scrolling icon for 2 seconds.
+	//
+	function show_icon_for_two_seconds() {
 
-        //
-        //	1.	Fade in the icon.
-        //
-        $('#icon-scroll').fadeIn();
+		//
+		//	1.	Fade in the icon.
+		//
+		$('#icon-scroll').fadeIn();
 
-        //
-        //	2.	Set a timer for 2 seconds.
-        //
-        setTimeout(function () {
+		//
+		//	2.	Set a timer for 2 seconds.
+		//
+		setTimeout(function () {
 
-            //
-            //	1.	Fade out the icon after 2 seconds.
-            //
-            $('#icon-scroll').fadeOut();
+			//
+			//	1.	Fade out the icon after 2 seconds.
+			//
+			$('#icon-scroll').fadeOut();
 
-        }, 2000)
+		}, 2000)
 
-        //
-        //	3.	Listen for if the window starts scrolling, so we can hide the
-        //		icon. this way we live the user with a clean UI.
-        //
-        $(window).scroll(function () {
+		//
+		//	3.	Listen for if the window starts scrolling, so we can hide the
+		//		icon. this way we live the user with a clean UI.
+		//
+		$(window).scroll(function () {
 
-            //
-            //	4.	Hide the icon if the window scrolls.
-            //
-            $('#icon-scroll').fadeOut();
+			//
+			//	4.	Hide the icon if the window scrolls.
+			//
+			$('#icon-scroll').fadeOut();
 
-        });
-    }
+		});
+	}
 
-    //
-    //	Set a timer for 1 second after which we will display a scrolling
-    //	animation to help the user know that they can scroll the page down
-    //	to get more content.
-    //
-    setTimeout(function () {
+	//
+	//	Set a timer for 1 second after which we will display a scrolling
+	//	animation to help the user know that they can scroll the page down
+	//	to get more content.
+	//
+	setTimeout(function () {
 
-        //
-        //	1.	Check if the window has been scrolled from the top after 1
-        //		second.
-        //
-        if (!$(window).scrollTop()) {
+		//
+		//	1.	Check if the window has been scrolled from the top after 1
+		//		second.
+		//
+		if (!$(window).scrollTop()) {
 
-            //
-            //	1.	Call function to show the icon for 2 seconds.
-            //
-            show_icon_for_two_seconds();
-        }
+			//
+			//	1.	Call function to show the icon for 2 seconds.
+			//
+			show_icon_for_two_seconds();
+		}
 
-    }, 1000);
+	}, 1000);
 
 </script>

--- a/_input/views/home.html
+++ b/_input/views/home.html
@@ -1,172 +1,187 @@
-<div class="container full-screen d-flex flex-column justify-content-start justify-content-md-center">
-	<div class="row d-flex justify-content-center">
-		<div class="col-12 col-md-11 col-lg-8 d-flex flex-column justify-content-center mt-0 mt-sm-5" id="home_header">
-			<img class="mx-auto" src="./assets/img/_global/company_logo_rectangle.svg" id="home_header_logo" alt="logo" />
-			<p class="mt-3 text-center home-header-text">We build software with solid foundations to provide flexible solutions that are easily modified and extended.</p>
-		</div>
-	</div>
-	<div class="row d-flex position-relative icon-scroll-row">
-		<div class="icon-scroll" id="icon-scroll"></div>
-	</div>
+<div class="container full-screen-container d-flex flex-column justify-content-start justify-content-md-center">
+    <div class="row d-flex justify-content-center">
+        <div class="col-12 col-md-11 col-lg-8 d-flex flex-column justify-content-center mt-0 mt-sm-5" id="home_header">
+            <img class="mx-auto" src="./assets/img/_global/company_logo_rectangle.svg" id="home_header_logo" alt="logo" />
+            <p class="mt-3 text-center home-header-text">We build software with solid foundations to provide flexible
+                solutions
+                that are easily modified and extended.</p>
+        </div>
+    </div>
+    <div class="row d-flex position-relative icon-scroll-row">
+        <div class="icon-scroll" id="icon-scroll"></div>
+    </div>
 </div>
 
 <div class="container marketing">
 
-	<div class="row">
-		<div class="col-lg-4">
-			<picture class="rounded-circle">
-			<source srcset="./assets/img/home/circles/circle1@1x.jpg 1x, ./assets/img/home/circles/circle1@2x.jpg 2x" />
-			<img src="./assets/img/home/circles/circle1@1x.jpg" alt="We Can Manage" width="140" height="140" />
-			</picture>
-			<h2>We Can Manage</h2>
-			<p>100% — if you have an idea, but lack the technical experience required to run a software project, we can help you.</p>
-		</div>
-		<div class="col-lg-4">
-			<picture class="rounded-circle">
-				<source srcset="./assets/img/home/circles/circle2@1x.jpg 1x, ./assets/img/home/circles/circle2@2x.jpg 2x" />
-				<img src="./assets/img/home/circles/circle2@1x.jpg" alt="We Can Build" width="140" height="140" />
-			</picture>
-			<h2>We Can Build</h2>
-			<p>We sure can! Just describe your problem, and we'll come up with a clean architecture, write the necessary code, and make it work.</p>
-		</div>
-		<div class="col-lg-4">
-			<picture class="rounded-circle">
-				<source srcset="./assets/img/home/circles/circle3@1x.jpg 1x, ./assets/img/home/circles/circle3@2x.jpg 2x" />
-				<img src="./assets/img/home/circles/circle3@1x.jpg" alt="We Can Research" width="140" height="140" />
-			</picture>
-			<h2>We Can Research</h2>
-			<p>0x4447™ will find a way. Bring us your new and original idea, and we'll do the R&D for you. We'll come up with a solution.</p>
-		</div>
-	</div>
+    <div class="row full-height-row d-flex align-items-center">
+        <div class="col-lg-4">
+            <picture class="rounded-circle">
+                <source srcset="./assets/img/home/circles/circle1@1x.jpg 1x, ./assets/img/home/circles/circle1@2x.jpg 2x" />
+                <img src="./assets/img/home/circles/circle1@1x.jpg" alt="We Can Manage" width="140" height="140" />
+            </picture>
+            <h2>We Can Manage</h2>
+            <p>100% — if you have an idea, but lack the technical experience required to run a software project, we can
+                help
+                you.</p>
+        </div>
+        <div class="col-lg-4">
+            <picture class="rounded-circle">
+                <source srcset="./assets/img/home/circles/circle2@1x.jpg 1x, ./assets/img/home/circles/circle2@2x.jpg 2x" />
+                <img src="./assets/img/home/circles/circle2@1x.jpg" alt="We Can Build" width="140" height="140" />
+            </picture>
+            <h2>We Can Build</h2>
+            <p>We sure can! Just describe your problem, and we'll come up with a clean architecture, write the
+                necessary code,
+                and make it work.</p>
+        </div>
+        <div class="col-lg-4">
+            <picture class="rounded-circle">
+                <source srcset="./assets/img/home/circles/circle3@1x.jpg 1x, ./assets/img/home/circles/circle3@2x.jpg 2x" />
+                <img src="./assets/img/home/circles/circle3@1x.jpg" alt="We Can Research" width="140" height="140" />
+            </picture>
+            <h2>We Can Research</h2>
+            <p>0x4447™ will find a way. Bring us your new and original idea, and we'll do the R&D for you. We'll come
+                up with a
+                solution.</p>
+        </div>
+    </div>
 
-	<hr class="featurette-divider" id="we_can_manage">
+    <div class="row featurette full-height-row d-flex align-items-center" id="we_can_manage">
+        <div class="col-md-6 order-md-2 order-sm-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/home/squares/square1@1x.jpg 1x, ./assets/img/home/squares/square1@2x.jpg 2x">
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square1@1x.jpg" alt="We Can Manage">
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-1 order-sm-2">
+            <h2 class="featurette-heading hover-link-container">
+                We Can Manage
+                <a href="#we_can_manage">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">Collectively, 0x4447 has logged dozens of years of collective experience. We've worked in
+                different
+                capacities at a range of companies. That work included numerous projects, products, and more. Through
+                it all, we
+                learned how to bring out the best in people and how to organize and manage a project by building a
+                solid foundation
+                that allows for easy expansion, maintenance, and adaptation to the changing times.</p>
+        </div>
+    </div>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-2 order-sm-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/home/squares/square1@1x.jpg 1x, ./assets/img/home/squares/square1@2x.jpg 2x">
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square1@1x.jpg" alt="We Can Manage">
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-1 order-sm-2">
-			<h2 class="featurette-heading hover-link-container">
-				We Can Manage
-				<a href="#we_can_manage">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">Collectively, 0x4447 has logged dozens of years of collective experience. We've worked in different capacities at a range of companies. That work included numerous projects, products, and more. Through it all, we learned how to bring out the best in people and how to organize and manage a project by building a solid foundation that allows for easy expansion, maintenance, and adaptation to the changing times.</p>
-		</div>
-	</div>
+    <div class="row featurette full-height-row d-flex align-items-center" id="we_can_build">
+        <div class="col-md-6 order-md-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/home/squares/square2@1x.jpg 1x, ./assets/img/home/squares/square2@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square2@1x.jpg" alt="We Can Build" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-2">
+            <h2 class="featurette-heading hover-link-container">
+                We Can Build
+                <a href="#we_can_build">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">Over the years, we've built regular sites, created efficient back-end solutions, designed
+                and
+                implemented custom protocols, and designed systems that work effectively and serve our clients well.</p>
+            <p class="lead">We understand how computers work, and we're familiar with all of their components, so we're
+                able to
+                tell them to do whatever we want them to do. The only thing we can't do is break the laws of physics.</p>
+        </div>
+    </div>
 
-	<hr class="featurette-divider" id="we_can_build">
+    <div class="row featurette full-height-row d-flex align-items-center" id="we_can_research">
+        <div class="col-md-6 order-md-2 order-sm-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/home/squares/square3@1x.jpg 1x, ./assets/img/home/squares/square3@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square3@1x.jpg" alt="We Can Research" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-1 order-sm-2">
+            <h2 class="featurette-heading hover-link-container">
+                We Can Research
+                <a href="#we_can_research">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">To stay competitive, you have to consistently create new features based on constant
+                research.</p>
+            <p class="lead">When it comes to R&D, you won't find a better company than 0x4447. We're always questioning
+                the
+                world, turning over every rock to see what's underneath, and unceasingly asking why. We're inquisitive
+                by design.</p>
+        </div>
+    </div>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/home/squares/square2@1x.jpg 1x, ./assets/img/home/squares/square2@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square2@1x.jpg" alt="We Can Build" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-2">
-			<h2 class="featurette-heading hover-link-container">
-				We Can Build
-				<a href="#we_can_build">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">Over the years, we've built regular sites, created efficient back-end solutions, designed and implemented custom protocols, and designed systems that work effectively and serve our clients well.</p>
-			<p class="lead">We understand how computers work, and we're familiar with all of their components, so we're able to tell them to do whatever we want them to do. The only thing we can't do is break the laws of physics.</p>
-		</div>
-	</div>
+    <hr class="featurette-divider">
 
-	<hr class="featurette-divider" id="we_can_research">
+    <h1>The Next Step</h1>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-2 order-sm-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/home/squares/square3@1x.jpg 1x, ./assets/img/home/squares/square3@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/home/squares/square3@1x.jpg" alt="We Can Research" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-1 order-sm-2">
-			<h2 class="featurette-heading hover-link-container">
-				We Can Research
-				<a href="#we_can_research">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">To stay competitive, you have to consistently create new features based on constant research.</p>
-			<p class="lead">When it comes to R&D, you won't find a better company than 0x4447. We're always questioning the world, turning over every rock to see what's underneath, and unceasingly asking why. We're inquisitive by design.</p>
-		</div>
-	</div>
-
-	<hr class="featurette-divider">
-
-	<h1>The Next Step</h1>
-
-	<p>Now that you know a little bit more about what we can do, check out <a href="about.html">why we do what we do</a>.</p>
+    <p>Now that you know a little bit more about what we can do, check out <a href="about.html">why we do what we do</a>.</p>
 
 </div>
 
 <script>
 
-//
-//	Shows a `div` containing a scrolling icon for 2 seconds.
-//
-function show_icon_for_two_seconds() {
+    //
+    //	Shows a `div` containing a scrolling icon for 2 seconds.
+    //
+    function show_icon_for_two_seconds() {
 
-	//
-	//	1.	Fade in the icon.
-	//
-	$('#icon-scroll').fadeIn();
+        //
+        //	1.	Fade in the icon.
+        //
+        $('#icon-scroll').fadeIn();
 
-	//
-	//	2.	Set a timer for 2 seconds.
-	//
-	setTimeout(function() {
+        //
+        //	2.	Set a timer for 2 seconds.
+        //
+        setTimeout(function () {
 
-		//
-		//	1.	Fade out the icon after 2 seconds.
-		//
-		$('#icon-scroll').fadeOut();
+            //
+            //	1.	Fade out the icon after 2 seconds.
+            //
+            $('#icon-scroll').fadeOut();
 
-	}, 2000)
+        }, 2000)
 
-	//
-	//	3.	Listen for if the window starts scrolling, so we can hide the
-	//		icon. this way we live the user with a clean UI.
-	//
-	$(window).scroll(function() {
+        //
+        //	3.	Listen for if the window starts scrolling, so we can hide the
+        //		icon. this way we live the user with a clean UI.
+        //
+        $(window).scroll(function () {
 
-		//
-		//	4.	Hide the icon if the window scrolls.
-		//
-		$('#icon-scroll').fadeOut();
+            //
+            //	4.	Hide the icon if the window scrolls.
+            //
+            $('#icon-scroll').fadeOut();
 
-	});
-}
+        });
+    }
 
-//
-//	Set a timer for 1 second after which we will display a scrolling
-//	animation to help the user know that they can scroll the page down
-//	to get more content.
-//
-setTimeout(function() {
+    //
+    //	Set a timer for 1 second after which we will display a scrolling
+    //	animation to help the user know that they can scroll the page down
+    //	to get more content.
+    //
+    setTimeout(function () {
 
-	//
-	//	1.	Check if the window has been scrolled from the top after 1
-	//		second.
-	//
-	if(!$(window).scrollTop())
-	{
+        //
+        //	1.	Check if the window has been scrolled from the top after 1
+        //		second.
+        //
+        if (!$(window).scrollTop()) {
 
-		//
-		//	1.	Call function to show the icon for 2 seconds.
-		//
-		show_icon_for_two_seconds();
-	}
+            //
+            //	1.	Call function to show the icon for 2 seconds.
+            //
+            show_icon_for_two_seconds();
+        }
 
-}, 1000);
+    }, 1000);
 
 </script>

--- a/_input/views/ideas.html
+++ b/_input/views/ideas.html
@@ -1,249 +1,249 @@
 <div class="container full-screen-container d-flex flex-column justify-content-start justify-content-md-center">
-    <div id="header" class="container">
-        <picture>
-            <source srcset="./assets/img/ideas/header@1x.jpg 1x, ./assets/img/ideas/header@2x.jpg 2x" />
-            <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/header@1x.jpg" alt="We can manage" />
-        </picture>
-    </div>
-    <h1>Some ideas that we can work on together</h1>
+	<div id="header" class="container">
+		<picture>
+			<source srcset="./assets/img/ideas/header@1x.jpg 1x, ./assets/img/ideas/header@2x.jpg 2x" />
+			<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/header@1x.jpg" alt="We can manage" />
+		</picture>
+	</div>
+	<h1>Some ideas that we can work on together</h1>
 
-    <p>We created a list of ideas that will help you understand what we can do for you. This is for sure not all we can
-        do, but it is a good showcase of the latest technologies and trends on the market that we can take advantage of
-        to
-        make your idea a reality.</p>
+	<p>We created a list of ideas that will help you understand what we can do for you. This is for sure not all we can
+		do, but it is a good showcase of the latest technologies and trends on the market that we can take advantage of
+		to
+		make your idea a reality.</p>
 </div>
 
 <div class="container marketing">
 
-    <div class="row full-height-row d-flex align-items-center" id="go_serverless">
-        <div class="col-md-6 order-md-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/ideas/squares/square1@1x.jpg 1x, ./assets/img/ideas/squares/square1@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square1@1x.jpg" alt="We can manage" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-2">
-            <h2 class="featurette-heading hover-link-container">
-                Go Serverless
-                <a href="#go_serverless">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">The serverless movement is picking up in popularity, and rightfully so. Since there are no
-                servers
-                to manage, nothing to hack in to, take over or assimilate in to a bot net. We always recommend starting
-                serverless
-                and then brake out to a custom server only if needed.</p>
-        </div>
-    </div>
+	<div class="row full-height-row d-flex align-items-center" id="go_serverless">
+		<div class="col-md-6 order-md-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/ideas/squares/square1@1x.jpg 1x, ./assets/img/ideas/squares/square1@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square1@1x.jpg" alt="We can manage" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-2">
+			<h2 class="featurette-heading hover-link-container">
+				Go Serverless
+				<a href="#go_serverless">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">The serverless movement is picking up in popularity, and rightfully so. Since there are no
+				servers
+				to manage, nothing to hack in to, take over or assimilate in to a bot net. We always recommend starting
+				serverless
+				and then brake out to a custom server only if needed.</p>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="iot_with_aws">
-        <div class="col-md-6 order-md-2 order-sm-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/ideas/squares/square2@1x.jpg 1x, ./assets/img/ideas/squares/square2@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square2@1x.jpg" alt="We can manage" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-1 order-sm-2">
-            <h2 class="featurette-heading hover-link-container">
-                IoT with AWS
-                <a href="#iot_with_aws">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">The Internet of Things is here to stay, and we are here to help you implement a full
-                back-end secure
-                solution that can handle thens of thousands of remote devices across the globe with real time secure
-                communication
-                by implementing a custom solution or taking advantage of AWS IoT.</p>
-        </div>
+	<div class="row full-height-row d-flex align-items-center" id="iot_with_aws">
+		<div class="col-md-6 order-md-2 order-sm-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/ideas/squares/square2@1x.jpg 1x, ./assets/img/ideas/squares/square2@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square2@1x.jpg" alt="We can manage" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-1 order-sm-2">
+			<h2 class="featurette-heading hover-link-container">
+				IoT with AWS
+				<a href="#iot_with_aws">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">The Internet of Things is here to stay, and we are here to help you implement a full
+				back-end secure
+				solution that can handle thens of thousands of remote devices across the globe with real time secure
+				communication
+				by implementing a custom solution or taking advantage of AWS IoT.</p>
+		</div>
 
-    </div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="data_pipeline">
-        <div class="col-md-6 order-md-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/ideas/squares/square3@1x.jpg 1x, ./assets/img/ideas/squares/square3@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square3@1x.jpg" alt="We can manage" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-2">
-            <h2 class="featurette-heading hover-link-container">
-                Data Pipeline
-                <a href="#data_pipeline">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">Do you need to ingest thousands of data points a second, process this data, convert it in
-                to a
-                different format, store it and make it ready to be queried for later manipulation? AWS Kinesis is your
-                best bet. We
-                can help you setup a full data pipeline flow from start to finish.</p>
-        </div>
-    </div>
+	<div class="row full-height-row d-flex align-items-center" id="data_pipeline">
+		<div class="col-md-6 order-md-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/ideas/squares/square3@1x.jpg 1x, ./assets/img/ideas/squares/square3@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square3@1x.jpg" alt="We can manage" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-2">
+			<h2 class="featurette-heading hover-link-container">
+				Data Pipeline
+				<a href="#data_pipeline">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">Do you need to ingest thousands of data points a second, process this data, convert it in
+				to a
+				different format, store it and make it ready to be queried for later manipulation? AWS Kinesis is your
+				best bet. We
+				can help you setup a full data pipeline flow from start to finish.</p>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="alexa_skill">
-        <div class="col-md-6 order-md-2 order-sm-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/ideas/squares/square4@1x.jpg 1x, ./assets/img/ideas/squares/square4@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square4@1x.jpg" alt="We can manage" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-1 order-sm-2">
-            <h2 class="featurette-heading hover-link-container">
-                Alexa Skill
-                <a href="#alexa_skill">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">The future of computing for consumers is voice. We an help you crate an interactive
-                experience that
-                feels natural to your customers. If you need an Alexa Skill to take in orders, answer questions and
-                interact with
-                your user base, we can make it happen.</p>
-        </div>
-    </div>
+	<div class="row full-height-row d-flex align-items-center" id="alexa_skill">
+		<div class="col-md-6 order-md-2 order-sm-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/ideas/squares/square4@1x.jpg 1x, ./assets/img/ideas/squares/square4@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square4@1x.jpg" alt="We can manage" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-1 order-sm-2">
+			<h2 class="featurette-heading hover-link-container">
+				Alexa Skill
+				<a href="#alexa_skill">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">The future of computing for consumers is voice. We an help you crate an interactive
+				experience that
+				feels natural to your customers. If you need an Alexa Skill to take in orders, answer questions and
+				interact with
+				your user base, we can make it happen.</p>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="aws_cognito">
-        <div class="col-md-6 order-md-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/ideas/squares/square5@1x.jpg 1x, ./assets/img/ideas/squares/square5@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square5@1x.jpg" alt="We can manage" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-2">
-            <h2 class="featurette-heading hover-link-container">
-                AWS Cognito
-                <a href="#aws_cognito">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">Taking care of security is not an easy task. That is why we like to go serverless, there is
-                less
-                moving parts that can go wrong. Authentication is one of those things. Why reinvent the wheel if you
-                can take
-                advantage of what the Cloud has to offer.</p>
-            <p class="lead">With Cognito not only we can implement a registration and login process from start to
-                finish, we can
-                easily implement social logins, SAML and SSO.</p>
-        </div>
-    </div>
+	<div class="row full-height-row d-flex align-items-center" id="aws_cognito">
+		<div class="col-md-6 order-md-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/ideas/squares/square5@1x.jpg 1x, ./assets/img/ideas/squares/square5@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square5@1x.jpg" alt="We can manage" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-2">
+			<h2 class="featurette-heading hover-link-container">
+				AWS Cognito
+				<a href="#aws_cognito">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">Taking care of security is not an easy task. That is why we like to go serverless, there is
+				less
+				moving parts that can go wrong. Authentication is one of those things. Why reinvent the wheel if you
+				can take
+				advantage of what the Cloud has to offer.</p>
+			<p class="lead">With Cognito not only we can implement a registration and login process from start to
+				finish, we can
+				easily implement social logins, SAML and SSO.</p>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="call_center_in_the_cloud">
-        <div class="col-md-6 order-md-2 order-sm-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/ideas/squares/square6@1x.jpg 1x, ./assets/img/ideas/squares/square6@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square6@1x.jpg" alt="We can manage" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-1 order-sm-2">
-            <h2 class="featurette-heading hover-link-container">
-                A call center in the Cloud
-                <a href="#call_center_in_the_cloud">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">Having a human interact with you customers is key to create a long lasting bond. The best
-                solution
-                is having a call center in the Cloud with AWS Connect.</p>
-            <p class="lead">With Connect you cane automate and interact with your customers any time of the day and
-                from any
-                place on the planet. The possibilities are endless.</p>
-        </div>
-    </div>
+	<div class="row full-height-row d-flex align-items-center" id="call_center_in_the_cloud">
+		<div class="col-md-6 order-md-2 order-sm-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/ideas/squares/square6@1x.jpg 1x, ./assets/img/ideas/squares/square6@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square6@1x.jpg" alt="We can manage" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-1 order-sm-2">
+			<h2 class="featurette-heading hover-link-container">
+				A call center in the Cloud
+				<a href="#call_center_in_the_cloud">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">Having a human interact with you customers is key to create a long lasting bond. The best
+				solution
+				is having a call center in the Cloud with AWS Connect.</p>
+			<p class="lead">With Connect you cane automate and interact with your customers any time of the day and
+				from any
+				place on the planet. The possibilities are endless.</p>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="aws_management">
-        <div class="col-md-6 order-md-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/ideas/squares/square7@1x.jpg 1x, ./assets/img/ideas/squares/square7@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square7@1x.jpg" alt="We can manage" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-2">
-            <h2 class="featurette-heading hover-link-container">
-                AWS Management
-                <a href="#aws_management">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">If you reached a point where your AWS infrastructure grew beyond your capabilities to
-                manage it, let
-                us help you with the DevOps approach and automation. By taking advantage of AWS Config, Lambda,
-                CloudWatch and all
-                the other serverless offerings, we can build a system that will manage the AWS for you.</p>
-            <p class="lead">It will monitor security, it will automatically deploy your project, it will notify you of
-                any
-                issues, and more. Don't do it by hand when code can do it for you.</p>
-        </div>
-    </div>
+	<div class="row full-height-row d-flex align-items-center" id="aws_management">
+		<div class="col-md-6 order-md-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/ideas/squares/square7@1x.jpg 1x, ./assets/img/ideas/squares/square7@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square7@1x.jpg" alt="We can manage" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-2">
+			<h2 class="featurette-heading hover-link-container">
+				AWS Management
+				<a href="#aws_management">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">If you reached a point where your AWS infrastructure grew beyond your capabilities to
+				manage it, let
+				us help you with the DevOps approach and automation. By taking advantage of AWS Config, Lambda,
+				CloudWatch and all
+				the other serverless offerings, we can build a system that will manage the AWS for you.</p>
+			<p class="lead">It will monitor security, it will automatically deploy your project, it will notify you of
+				any
+				issues, and more. Don't do it by hand when code can do it for you.</p>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="restful_api">
-        <div class="col-md-6 order-md-2 order-sm-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/ideas/squares/square8@1x.jpg 1x, ./assets/img/ideas/squares/square8@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square8@1x.jpg" alt="We can manage" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-1 order-sm-2">
-            <h2 class="featurette-heading hover-link-container">
-                RESTful API
-                <a href="#restful_api">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">Today having an API is the key for your product success. If you need to have a platform for
-                other
-                developers, the best way is to do it using API Gateway. There is nothing to manage, it automatically
-                takes cares of
-                API Keys, throttling, cashing, versioning and more.</p>
-            <p class="lead">We can design and implement an API that developers will love to use.</p>
-        </div>
-    </div>
+	<div class="row full-height-row d-flex align-items-center" id="restful_api">
+		<div class="col-md-6 order-md-2 order-sm-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/ideas/squares/square8@1x.jpg 1x, ./assets/img/ideas/squares/square8@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square8@1x.jpg" alt="We can manage" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-1 order-sm-2">
+			<h2 class="featurette-heading hover-link-container">
+				RESTful API
+				<a href="#restful_api">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">Today having an API is the key for your product success. If you need to have a platform for
+				other
+				developers, the best way is to do it using API Gateway. There is nothing to manage, it automatically
+				takes cares of
+				API Keys, throttling, cashing, versioning and more.</p>
+			<p class="lead">We can design and implement an API that developers will love to use.</p>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="socket_server">
-        <div class="col-md-6 order-md-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/ideas/squares/square9@1x.jpg 1x, ./assets/img/ideas/squares/square9@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square9@1x.jpg" alt="We can manage" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-2">
-            <h2 class="featurette-heading hover-link-container">
-                Socket Server
-                <a href="#socket_server">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">We can go even deeper then serverless, when your project is 100% custom and have it's own
-                protocol
-                for communication with the world, we can build a server that will communicate with it.</p>
-        </div>
-    </div>
+	<div class="row full-height-row d-flex align-items-center" id="socket_server">
+		<div class="col-md-6 order-md-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/ideas/squares/square9@1x.jpg 1x, ./assets/img/ideas/squares/square9@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square9@1x.jpg" alt="We can manage" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-2">
+			<h2 class="featurette-heading hover-link-container">
+				Socket Server
+				<a href="#socket_server">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">We can go even deeper then serverless, when your project is 100% custom and have it's own
+				protocol
+				for communication with the world, we can build a server that will communicate with it.</p>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="protocol_design">
-        <div class="col-md-6 order-md-2 order-sm-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/ideas/squares/square10@1x.jpg 1x, ./assets/img/ideas/squares/square10@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square10@1x.jpg" alt="We can manage" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-1 order-sm-2">
-            <h2 class="featurette-heading hover-link-container">
-                Protocol Design
-                <a href="#protocol_design">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">We love specialized project that require low level knowledge. If you need a custom way to
-                communicate with other parts of your project we can help you design a custom protocol with a fantastic
-                documentation to help anyone understand how it works.</p>
-        </div>
-    </div>
+	<div class="row full-height-row d-flex align-items-center" id="protocol_design">
+		<div class="col-md-6 order-md-2 order-sm-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/ideas/squares/square10@1x.jpg 1x, ./assets/img/ideas/squares/square10@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square10@1x.jpg" alt="We can manage" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-1 order-sm-2">
+			<h2 class="featurette-heading hover-link-container">
+				Protocol Design
+				<a href="#protocol_design">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">We love specialized project that require low level knowledge. If you need a custom way to
+				communicate with other parts of your project we can help you design a custom protocol with a fantastic
+				documentation to help anyone understand how it works.</p>
+		</div>
+	</div>
 
-    <hr class="featurette-divider">
+	<hr class="featurette-divider">
 
-    <h1>The Next Step</h1>
+	<h1>The Next Step</h1>
 
-    <p>Now that we give you some ideas, check out <a href="clients.html">who has already placed their trust in us</a>.</p>
+	<p>Now that we give you some ideas, check out <a href="clients.html">who has already placed their trust in us</a>.</p>
 
 </div>

--- a/_input/views/ideas.html
+++ b/_input/views/ideas.html
@@ -1,225 +1,249 @@
-<div id="header" class="container">
-	<picture>
-		<source srcset="./assets/img/ideas/header@1x.jpg 1x, ./assets/img/ideas/header@2x.jpg 2x" />
-		<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/header@1x.jpg" alt="We can manage" />
-	</picture>
+<div class="container full-screen-container d-flex flex-column justify-content-start justify-content-md-center">
+    <div id="header" class="container">
+        <picture>
+            <source srcset="./assets/img/ideas/header@1x.jpg 1x, ./assets/img/ideas/header@2x.jpg 2x" />
+            <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/header@1x.jpg" alt="We can manage" />
+        </picture>
+    </div>
+    <h1>Some ideas that we can work on together</h1>
+
+    <p>We created a list of ideas that will help you understand what we can do for you. This is for sure not all we can
+        do, but it is a good showcase of the latest technologies and trends on the market that we can take advantage of
+        to
+        make your idea a reality.</p>
 </div>
 
 <div class="container marketing">
 
-	<h1>Some ideas that we can work on together</h1>
+    <div class="row full-height-row d-flex align-items-center" id="go_serverless">
+        <div class="col-md-6 order-md-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/ideas/squares/square1@1x.jpg 1x, ./assets/img/ideas/squares/square1@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square1@1x.jpg" alt="We can manage" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-2">
+            <h2 class="featurette-heading hover-link-container">
+                Go Serverless
+                <a href="#go_serverless">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">The serverless movement is picking up in popularity, and rightfully so. Since there are no
+                servers
+                to manage, nothing to hack in to, take over or assimilate in to a bot net. We always recommend starting
+                serverless
+                and then brake out to a custom server only if needed.</p>
+        </div>
+    </div>
 
-	<p>We created a list of ideas that will help you understand what we can do for you. This is for sure not all we can do, but it is a good showcase of the latest technologies and trends on the market that we can take advantage of to make your idea a reality.</p>
+    <div class="row full-height-row d-flex align-items-center" id="iot_with_aws">
+        <div class="col-md-6 order-md-2 order-sm-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/ideas/squares/square2@1x.jpg 1x, ./assets/img/ideas/squares/square2@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square2@1x.jpg" alt="We can manage" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-1 order-sm-2">
+            <h2 class="featurette-heading hover-link-container">
+                IoT with AWS
+                <a href="#iot_with_aws">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">The Internet of Things is here to stay, and we are here to help you implement a full
+                back-end secure
+                solution that can handle thens of thousands of remote devices across the globe with real time secure
+                communication
+                by implementing a custom solution or taking advantage of AWS IoT.</p>
+        </div>
 
-	<hr class="featurette-divider" id="go_serverless">
+    </div>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/ideas/squares/square1@1x.jpg 1x, ./assets/img/ideas/squares/square1@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square1@1x.jpg" alt="We can manage" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-2">
-			<h2 class="featurette-heading hover-link-container">
-				Go Serverless
-				<a href="#go_serverless">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">The serverless movement is picking up in popularity, and rightfully so. Since there are no servers to manage, nothing to hack in to, take over or assimilate in to a bot net. We always recommend starting serverless and then brake out to a custom server only if needed.</p>
-		</div>
-	</div>
+    <div class="row full-height-row d-flex align-items-center" id="data_pipeline">
+        <div class="col-md-6 order-md-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/ideas/squares/square3@1x.jpg 1x, ./assets/img/ideas/squares/square3@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square3@1x.jpg" alt="We can manage" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-2">
+            <h2 class="featurette-heading hover-link-container">
+                Data Pipeline
+                <a href="#data_pipeline">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">Do you need to ingest thousands of data points a second, process this data, convert it in
+                to a
+                different format, store it and make it ready to be queried for later manipulation? AWS Kinesis is your
+                best bet. We
+                can help you setup a full data pipeline flow from start to finish.</p>
+        </div>
+    </div>
 
-	<hr class="featurette-divider" id="iot_with_aws">
+    <div class="row full-height-row d-flex align-items-center" id="alexa_skill">
+        <div class="col-md-6 order-md-2 order-sm-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/ideas/squares/square4@1x.jpg 1x, ./assets/img/ideas/squares/square4@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square4@1x.jpg" alt="We can manage" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-1 order-sm-2">
+            <h2 class="featurette-heading hover-link-container">
+                Alexa Skill
+                <a href="#alexa_skill">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">The future of computing for consumers is voice. We an help you crate an interactive
+                experience that
+                feels natural to your customers. If you need an Alexa Skill to take in orders, answer questions and
+                interact with
+                your user base, we can make it happen.</p>
+        </div>
+    </div>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-2 order-sm-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/ideas/squares/square2@1x.jpg 1x, ./assets/img/ideas/squares/square2@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square2@1x.jpg" alt="We can manage" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-1 order-sm-2">
-			<h2 class="featurette-heading hover-link-container">
-				IoT with AWS
-				<a href="#iot_with_aws">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">The Internet of Things is here to stay, and we are here to help you implement a full back-end secure solution that can handle thens of thousands of remote devices across the globe with real time secure communication by implementing a custom solution or taking advantage of AWS IoT.</p>
-		</div>
+    <div class="row full-height-row d-flex align-items-center" id="aws_cognito">
+        <div class="col-md-6 order-md-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/ideas/squares/square5@1x.jpg 1x, ./assets/img/ideas/squares/square5@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square5@1x.jpg" alt="We can manage" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-2">
+            <h2 class="featurette-heading hover-link-container">
+                AWS Cognito
+                <a href="#aws_cognito">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">Taking care of security is not an easy task. That is why we like to go serverless, there is
+                less
+                moving parts that can go wrong. Authentication is one of those things. Why reinvent the wheel if you
+                can take
+                advantage of what the Cloud has to offer.</p>
+            <p class="lead">With Cognito not only we can implement a registration and login process from start to
+                finish, we can
+                easily implement social logins, SAML and SSO.</p>
+        </div>
+    </div>
 
-	</div>
+    <div class="row full-height-row d-flex align-items-center" id="call_center_in_the_cloud">
+        <div class="col-md-6 order-md-2 order-sm-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/ideas/squares/square6@1x.jpg 1x, ./assets/img/ideas/squares/square6@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square6@1x.jpg" alt="We can manage" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-1 order-sm-2">
+            <h2 class="featurette-heading hover-link-container">
+                A call center in the Cloud
+                <a href="#call_center_in_the_cloud">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">Having a human interact with you customers is key to create a long lasting bond. The best
+                solution
+                is having a call center in the Cloud with AWS Connect.</p>
+            <p class="lead">With Connect you cane automate and interact with your customers any time of the day and
+                from any
+                place on the planet. The possibilities are endless.</p>
+        </div>
+    </div>
 
-	<hr class="featurette-divider" id="data_pipeline">
+    <div class="row full-height-row d-flex align-items-center" id="aws_management">
+        <div class="col-md-6 order-md-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/ideas/squares/square7@1x.jpg 1x, ./assets/img/ideas/squares/square7@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square7@1x.jpg" alt="We can manage" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-2">
+            <h2 class="featurette-heading hover-link-container">
+                AWS Management
+                <a href="#aws_management">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">If you reached a point where your AWS infrastructure grew beyond your capabilities to
+                manage it, let
+                us help you with the DevOps approach and automation. By taking advantage of AWS Config, Lambda,
+                CloudWatch and all
+                the other serverless offerings, we can build a system that will manage the AWS for you.</p>
+            <p class="lead">It will monitor security, it will automatically deploy your project, it will notify you of
+                any
+                issues, and more. Don't do it by hand when code can do it for you.</p>
+        </div>
+    </div>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/ideas/squares/square3@1x.jpg 1x, ./assets/img/ideas/squares/square3@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square3@1x.jpg" alt="We can manage" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-2">
-			<h2 class="featurette-heading hover-link-container">
-				Data Pipeline
-				<a href="#data_pipeline">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">Do you need to ingest thousands of data points a second, process this data, convert it in to a different format, store it and make it ready to be queried for later manipulation? AWS Kinesis is your best bet. We can help you setup a full data pipeline flow from start to finish.</p>
-		</div>
-	</div>
+    <div class="row full-height-row d-flex align-items-center" id="restful_api">
+        <div class="col-md-6 order-md-2 order-sm-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/ideas/squares/square8@1x.jpg 1x, ./assets/img/ideas/squares/square8@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square8@1x.jpg" alt="We can manage" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-1 order-sm-2">
+            <h2 class="featurette-heading hover-link-container">
+                RESTful API
+                <a href="#restful_api">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">Today having an API is the key for your product success. If you need to have a platform for
+                other
+                developers, the best way is to do it using API Gateway. There is nothing to manage, it automatically
+                takes cares of
+                API Keys, throttling, cashing, versioning and more.</p>
+            <p class="lead">We can design and implement an API that developers will love to use.</p>
+        </div>
+    </div>
 
-	<hr class="featurette-divider" id="alexa_skill">
+    <div class="row full-height-row d-flex align-items-center" id="socket_server">
+        <div class="col-md-6 order-md-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/ideas/squares/square9@1x.jpg 1x, ./assets/img/ideas/squares/square9@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square9@1x.jpg" alt="We can manage" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-2">
+            <h2 class="featurette-heading hover-link-container">
+                Socket Server
+                <a href="#socket_server">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">We can go even deeper then serverless, when your project is 100% custom and have it's own
+                protocol
+                for communication with the world, we can build a server that will communicate with it.</p>
+        </div>
+    </div>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-2 order-sm-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/ideas/squares/square4@1x.jpg 1x, ./assets/img/ideas/squares/square4@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square4@1x.jpg" alt="We can manage" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-1 order-sm-2">
-			<h2 class="featurette-heading hover-link-container">
-				Alexa Skill
-				<a href="#alexa_skill">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">The future of computing for consumers is voice. We an help you crate an interactive experience that feels natural to your customers. If you need an Alexa Skill to take in orders, answer questions and interact with your user base, we can make it happen.</p>
-		</div>
-	</div>
+    <div class="row full-height-row d-flex align-items-center" id="protocol_design">
+        <div class="col-md-6 order-md-2 order-sm-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/ideas/squares/square10@1x.jpg 1x, ./assets/img/ideas/squares/square10@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square10@1x.jpg" alt="We can manage" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-1 order-sm-2">
+            <h2 class="featurette-heading hover-link-container">
+                Protocol Design
+                <a href="#protocol_design">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">We love specialized project that require low level knowledge. If you need a custom way to
+                communicate with other parts of your project we can help you design a custom protocol with a fantastic
+                documentation to help anyone understand how it works.</p>
+        </div>
+    </div>
 
-	<hr class="featurette-divider" id="aws_cognito">
+    <hr class="featurette-divider">
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/ideas/squares/square5@1x.jpg 1x, ./assets/img/ideas/squares/square5@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square5@1x.jpg" alt="We can manage" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-2">
-			<h2 class="featurette-heading hover-link-container">
-				AWS Cognito
-				<a href="#aws_cognito">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">Taking care of security is not an easy task. That is why we like to go serverless, there is less moving parts that can go wrong. Authentication is one of those things. Why reinvent the wheel if you can take advantage of what the Cloud has to offer.</p>
-			<p class="lead">With Cognito not only we can implement a registration and login process from start to finish, we can easily implement social logins, SAML and SSO.</p>
-		</div>
-	</div>
+    <h1>The Next Step</h1>
 
-	<hr class="featurette-divider" id="call_center_in_the_cloud">
-
-	<div class="row featurette">
-		<div class="col-md-6 order-md-2 order-sm-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/ideas/squares/square6@1x.jpg 1x, ./assets/img/ideas/squares/square6@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square6@1x.jpg" alt="We can manage" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-1 order-sm-2">
-			<h2 class="featurette-heading hover-link-container">
-				A call center in the Cloud
-				<a href="#call_center_in_the_cloud">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">Having a human interact with you customers is key to create a long lasting bond. The best solution is having a call center in the Cloud with AWS Connect.</p>
-			<p class="lead">With Connect you cane automate and interact with your customers any time of the day and from any place on the planet. The possibilities are endless.</p>
-		</div>
-	</div>
-
-	<hr class="featurette-divider" id="aws_management">
-
-	<div class="row featurette">
-		<div class="col-md-6 order-md-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/ideas/squares/square7@1x.jpg 1x, ./assets/img/ideas/squares/square7@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square7@1x.jpg" alt="We can manage" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-2">
-			<h2 class="featurette-heading hover-link-container">
-				AWS Management
-				<a href="#aws_management">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">If you reached a point where your AWS infrastructure grew beyond your capabilities to manage it, let us help you with the DevOps approach and automation. By taking advantage of AWS Config, Lambda, CloudWatch and all the other serverless offerings, we can build a system that will manage the AWS for you.</p>
-			<p class="lead">It will monitor security, it will automatically deploy your project, it will notify you of any issues, and more. Don't do it by hand when code can do it for you.</p>
-		</div>
-	</div>
-
-	<hr class="featurette-divider" id="restful_api">
-
-	<div class="row featurette">
-		<div class="col-md-6 order-md-2 order-sm-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/ideas/squares/square8@1x.jpg 1x, ./assets/img/ideas/squares/square8@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square8@1x.jpg" alt="We can manage" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-1 order-sm-2">
-			<h2 class="featurette-heading hover-link-container">
-				RESTful API
-				<a href="#restful_api">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">Today having an API is the key for your product success. If you need to have a platform for other developers, the best way is to do it using API Gateway. There is nothing to manage, it automatically takes cares of API Keys, throttling, cashing, versioning and more.</p>
-			<p class="lead">We can design and implement an API that developers will love to use.</p>
-		</div>
-	</div>
-
-	<hr class="featurette-divider" id="socket_server">
-
-	<div class="row featurette">
-		<div class="col-md-6 order-md-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/ideas/squares/square9@1x.jpg 1x, ./assets/img/ideas/squares/square9@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square9@1x.jpg" alt="We can manage" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-2">
-			<h2 class="featurette-heading hover-link-container">
-				Socket Server
-				<a href="#socket_server">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">We can go even deeper then serverless, when your project is 100% custom and have it's own protocol for communication with the world, we can build a server that will communicate with it.</p>
-		</div>
-	</div>
-
-	<hr class="featurette-divider" id="protocol_design">
-
-	<div class="row featurette">
-		<div class="col-md-6 order-md-2 order-sm-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/ideas/squares/square10@1x.jpg 1x, ./assets/img/ideas/squares/square10@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/ideas/squares/square10@1x.jpg" alt="We can manage" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-1 order-sm-2">
-			<h2 class="featurette-heading hover-link-container">
-				Protocol Design
-				<a href="#protocol_design">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">We love specialized project that require low level knowledge. If you need a custom way to communicate with other parts of your project we can help you design a custom protocol with a fantastic documentation to help anyone understand how it works.</p>
-		</div>
-	</div>
-
-	<hr class="featurette-divider">
-
-	<h1>The Next Step</h1>
-
-	<p>Now that we give you some ideas, check out <a href="clients.html">who has already placed their trust in us</a>.</p>
+    <p>Now that we give you some ideas, check out <a href="clients.html">who has already placed their trust in us</a>.</p>
 
 </div>

--- a/_input/views/thankyou.html
+++ b/_input/views/thankyou.html
@@ -3,8 +3,8 @@
 		<source srcset="./assets/img/thankyou/header@1x.jpg 1x, ./assets/img/thankyou/header@2x.jpg 2x" />
 		<img class="featurette-image img-fluid mx-auto" src="./assets/img/thankyou/header@1x.jpg" alt="{{ title }}" />
 		<div class="placeholder-masker">
-            <div class="placeholder-animated-background"></div>
-        </div>
+			<div class="placeholder-animated-background"></div>
+		</div>
 	</picture>
 </div>
 

--- a/_input/views/toolbox.html
+++ b/_input/views/toolbox.html
@@ -1,195 +1,233 @@
-<div id="header" class="container">
-	<picture>
-		<source srcset="./assets/img/toolbox/header@1x.jpg 1x, ./assets/img/toolbox/header@2x.jpg 2x" />
-		<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/header@1x.jpg" alt="{{ title }}" />
-		<div class="placeholder-masker">
-            <div class="placeholder-animated-background"></div>
-        </div>
-	</picture>
+<div class="container full-screen-container d-flex flex-column justify-content-start justify-content-md-center">
+    <div id="header" class="container">
+        <picture>
+            <source srcset="./assets/img/toolbox/header@1x.jpg 1x, ./assets/img/toolbox/header@2x.jpg 2x" />
+            <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/header@1x.jpg" alt="{{ title }}" />
+            <div class="placeholder-masker">
+                <div class="placeholder-animated-background"></div>
+            </div>
+        </picture>
+    </div>
+    <h1>Our Open-Source Tools</h1>
+
+    <p>We love to be efficient, but we hate repetitive work! That's why we build tools that help us do the repetitive
+        work
+        for us. It's also why we share them with the world so that others can also benefit. We strongly believe in
+        sharing
+        knowledge in the simplest possible way so other people are able to learn what we already know. Sharing in this
+        way
+        allows us to help people create fresh ideas that will benefit our community.</p>
 </div>
 
 <div class="container marketing">
 
-	<h1>Our Open-Source Tools</h1>
+    <div class="row full-height-row d-flex align-items-center" id="potato">
+        <div class="col-md-6 order-md-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/toolbox/squares/square1@1x.jpg 1x, ./assets/img/toolbox/squares/square1@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square1@1x.jpg" alt="0x4447 Potato" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-2">
+            <h2 class="featurette-heading hover-link-container">
+                Potato
+                <a href="#potato">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">The purpose of 0x4447™'s Potato CLI tool is to streamline the process of hosting a static
+                web page
+                on S3 while using CloudFront to deliver the content.</p>
 
-	<p>We love to be efficient, but we hate repetitive work! That's why we build tools that help us do the repetitive work for us. It's also why we share them with the world so that others can also benefit. We strongly believe in sharing knowledge in the simplest possible way so other people are able to learn what we already know. Sharing in this way allows us to help people create fresh ideas that will benefit our community.</p>
+            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/potato"><img width="50" src="./assets/img/_global/npm.svg"
+                    alt="npm" /></a>
+            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-potato"><img width="20" src="./assets/img/_global/github.svg"
+                    alt="GitHub" /></a>
+            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-potato"><img width="20" src="./assets/img/_global/travisci.svg"
+                    alt="Travis" /></a>
+        </div>
+    </div>
 
-	<hr class="featurette-divider" id="potato">
+    <div class="row full-height-row d-flex align-items-center" id="tomato">
+        <div class="col-md-6 order-md-2 order-sm-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/toolbox/squares/square2@1x.jpg 1x, ./assets/img/toolbox/squares/square2@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square2@1x.jpg" alt="0x4447 Tomato" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-1 order-sm-2">
+            <h2 class="featurette-heading hover-link-container">
+                Tomato
+                <a href="#tomato">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">This is 0x4447's take on the express-generator CLI that's included with ExpressJS. We
+                created this
+                project because we'd always spend quite a bit of time on bringing the default ExpressJS template up to
+                speed. This
+                was especially true when there was a constant need to spin up new micro-services.</p>
+            <p class="lead">One of this project's nicest features is how simple it is for the user to customize it. If
+                you have
+                your own style, all you need to do is clone the repo and edit the source folder as you like.</p>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/toolbox/squares/square1@1x.jpg 1x, ./assets/img/toolbox/squares/square1@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square1@1x.jpg" alt="0x4447 Potato" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-2">
-			<h2 class="featurette-heading hover-link-container">
-				Potato
-				<a href="#potato">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">The purpose of 0x4447™'s Potato CLI tool is to streamline the process of hosting a static web page on S3 while using CloudFront to deliver the content.</p>
+            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/tomato"><img width="50" src="./assets/img/_global/npm.svg"
+                    alt="npm" /></a>
+            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-tomato"><img width="20" src="./assets/img/_global/github.svg"
+                    alt="GitHub" /></a>
+            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-tomato"><img width="20" src="./assets/img/_global/travisci.svg"
+                    alt="Travis" /></a>
+        </div>
 
-			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/potato"><img width="50" src="./assets/img/_global/npm.svg" alt="npm" /></a>
-			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-potato"><img width="20" src="./assets/img/_global/github.svg" alt="GitHub" /></a>
-			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-potato"><img width="20" src="./assets/img/_global/travisci.svg" alt="Travis" /></a>
-		</div>
-	</div>
+    </div>
 
-	<hr class="featurette-divider" id="tomato">
+    <div class="row full-height-row d-flex align-items-center" id="cucumber">
+        <div class="col-md-6 order-md-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/toolbox/squares/square3@1x.jpg 1x, ./assets/img/toolbox/squares/square3@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square3@1x.jpg" alt="0x4447 Cucumber" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-2">
+            <h2 class="featurette-heading hover-link-container">
+                Cucumber
+                <a href="#cucumber">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">Cucumber is a small, simple project that we created to save time as we work with Heroku. It
+                allows
+                us to easily auto-generate the .env file when we develop the project locally.</p>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-2 order-sm-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/toolbox/squares/square2@1x.jpg 1x, ./assets/img/toolbox/squares/square2@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square2@1x.jpg" alt="0x4447 Tomato" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-1 order-sm-2">
-			<h2 class="featurette-heading hover-link-container">
-				Tomato
-				<a href="#tomato">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">This is 0x4447's take on the express-generator CLI that's included with ExpressJS. We created this project because we'd always spend quite a bit of time on bringing the default ExpressJS template up to speed. This was especially true when there was a constant need to spin up new micro-services.</p>
-			<p class="lead">One of this project's nicest features is how simple it is for the user to customize it. If you have your own style, all you need to do is clone the repo and edit the source folder as you like.</p>
+            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/cucumber"><img width="50" src="./assets/img/_global/npm.svg"
+                    alt="npm" /></a>
+            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-cucumber"><img width="20" src="./assets/img/_global/github.svg"
+                    alt="GitHub" /></a>
+            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-cucumber"><img width="20" src="./assets/img/_global/travisci.svg"
+                    alt="Travis" /></a>
+        </div>
+    </div>
 
-			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/tomato"><img width="50" src="./assets/img/_global/npm.svg" alt="npm" /></a>
-			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-tomato"><img width="20" src="./assets/img/_global/github.svg" alt="GitHub" /></a>
-			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-tomato"><img width="20" src="./assets/img/_global/travisci.svg" alt="Travis" /></a>
-		</div>
+    <div class="row full-height-row d-flex align-items-center" id="hot_pepper">
+        <div class="col-md-6 order-md-2 order-sm-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/toolbox/squares/square4@1x.jpg 1x, ./assets/img/toolbox/squares/square4@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square4@1x.jpg" alt="0x4447 Hot Pepper" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-1 order-sm-2">
+            <h2 class="featurette-heading hover-link-container">
+                Hot Pepper
+                <a href="#hot_pepper">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">This project will save time for those who work with NodeJS projects and prefer to run them
+                on a
+                Linux box using SystemD as the process manager. It creates the SystemD .service file for you, based on
+                the content
+                of the package.json file.</p>
 
-	</div>
+            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/hotpepper"><img width="50" src="./assets/img/_global/npm.svg"
+                    alt="npm" /></a>
+            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-hot-pepper"><img width="20" src="./assets/img/_global/github.svg"
+                    alt="GitHub" /></a>
+            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-hot-pepper"><img width="20" src="./assets/img/_global/travisci.svg"
+                    alt="Travis" /></a>
+        </div>
+    </div>
 
-	<hr class="featurette-divider" id="cucumber">
+    <div class="row full-height-row d-flex align-items-center" id="broccoli">
+        <div class="col-md-6 order-md-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/toolbox/squares/square5@1x.jpg 1x, ./assets/img/toolbox/squares/square5@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square5@1x.jpg" alt="0x4447 Broccoli" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-2">
+            <h2 class="featurette-heading hover-link-container">
+                Broccoli
+                <a href="#broccoli">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">If you're a developer with a local Nginx setup, and you like to give the sites you work on
+                local
+                domain names, you've experienced the tedium of creating an Nginx config file and restarting Nginx to
+                load the new
+                configuration. This CLI automatically does all of that for you.</p>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/toolbox/squares/square3@1x.jpg 1x, ./assets/img/toolbox/squares/square3@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square3@1x.jpg" alt="0x4447 Cucumber" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-2">
-			<h2 class="featurette-heading hover-link-container">
-				Cucumber
-				<a href="#cucumber">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">Cucumber is a small, simple project that we created to save time as we work with Heroku. It allows us to easily auto-generate the .env file when we develop the project locally.</p>
+            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/broccoli"><img width="50" src="./assets/img/_global/npm.svg"
+                    alt="npm" /></a>
+            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-broccoli"><img width="20" src="./assets/img/_global/github.svg"
+                    alt="GitHub" /></a>
+            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-broccoli"><img width="20" src="./assets/img/_global/travisci.svg"
+                    alt="Travis" /></a>
+        </div>
+    </div>
 
-			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/cucumber"><img width="50" src="./assets/img/_global/npm.svg" alt="npm" /></a>
-			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-cucumber"><img width="20" src="./assets/img/_global/github.svg" alt="GitHub" /></a>
-			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-cucumber"><img width="20" src="./assets/img/_global/travisci.svg" alt="Travis" /></a>
-		</div>
-	</div>
+    <div class="row full-height-row d-flex align-items-center" id="avocado">
+        <div class="col-md-6 order-md-2 order-sm-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/toolbox/squares/square6@1x.jpg 1x, ./assets/img/toolbox/squares/square6@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square6@1x.jpg" alt="0x4447 Avocado" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-1 order-sm-2">
+            <h2 class="featurette-heading hover-link-container">
+                Avocado
+                <a href="#avocado">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">Deploying a simple HTML page that is not build around a framework to AWS CloudFront, is
+                annoying and
+                time consuming. This CLI will build the final page out of a simple folder structure by using the
+                awesome templating
+                engine—Hogan.</p>
 
-	<hr class="featurette-divider" id="hot_pepper">
+            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/avocado"><img width="50" src="./assets/img/_global/npm.svg"
+                    alt="npm" /></a>
+            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-avocado"><img width="20" src="./assets/img/_global/github.svg"
+                    alt="GitHub" /></a>
+            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-avocado"><img width="20" src="./assets/img/_global/travisci.svg"
+                    alt="Travis" /></a>
+        </div>
+    </div>
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-2 order-sm-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/toolbox/squares/square4@1x.jpg 1x, ./assets/img/toolbox/squares/square4@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square4@1x.jpg" alt="0x4447 Hot Pepper" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-1 order-sm-2">
-			<h2 class="featurette-heading hover-link-container">
-				Hot Pepper
-				<a href="#hot_pepper">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">This project will save time for those who work with NodeJS projects and prefer to run them on a Linux box using SystemD as the process manager. It creates the SystemD .service file for you, based on the content of the package.json file.</p>
+    <div class="row full-height-row d-flex align-items-center" id="strawberry">
+        <div class="col-md-6 order-md-1">
+            <picture class="featurette-image img-fluid mx-auto">
+                <source srcset="./assets/img/toolbox/squares/square7@1x.jpg 1x, ./assets/img/toolbox/squares/square7@2x.jpg 2x" />
+                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square7@1x.jpg" alt="0x4447 Broccoli" />
+            </picture>
+        </div>
+        <div class="col-md-6 order-md-2">
+            <h2 class="featurette-heading hover-link-container">
+                Strawberry
+                <a href="#strawberry">
+                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+                </a>
+            </h2>
+            <p class="lead">This CLI will automatically create a HTTPS redirect from one domain to another using what
+                AWS has to
+                offer – so you don't have to manage a server for a simple redirect.</p>
 
-			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/hotpepper"><img width="50" src="./assets/img/_global/npm.svg" alt="npm" /></a>
-			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-hot-pepper"><img width="20" src="./assets/img/_global/github.svg" alt="GitHub" /></a>
-			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-hot-pepper"><img width="20" src="./assets/img/_global/travisci.svg" alt="Travis" /></a>
-		</div>
-	</div>
+            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/strawberry"><img width="50" src="./assets/img/_global/npm.svg"
+                    alt="npm" /></a>
+            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-strawberry"><img width="20" src="./assets/img/_global/github.svg"
+                    alt="GitHub" /></a>
+            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-strawberry"><img width="20" src="./assets/img/_global/travisci.svg"
+                    alt="Travis" /></a>
+        </div>
+    </div>
 
-	<hr class="featurette-divider" id="broccoli">
+    <hr class="featurette-divider">
 
-	<div class="row featurette">
-		<div class="col-md-6 order-md-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/toolbox/squares/square5@1x.jpg 1x, ./assets/img/toolbox/squares/square5@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square5@1x.jpg" alt="0x4447 Broccoli" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-2">
-			<h2 class="featurette-heading hover-link-container">
-				Broccoli
-				<a href="#broccoli">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">If you're a developer with a local Nginx setup, and you like to give the sites you work on local domain names, you've experienced the tedium of creating an Nginx config file and restarting Nginx to load the new configuration. This CLI automatically does all of that for you.</p>
+    <h1>The Next Step</h1>
 
-			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/broccoli"><img width="50" src="./assets/img/_global/npm.svg" alt="npm" /></a>
-			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-broccoli"><img width="20" src="./assets/img/_global/github.svg" alt="GitHub" /></a>
-			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-broccoli"><img width="20" src="./assets/img/_global/travisci.svg" alt="Travis" /></a>
-		</div>
-	</div>
+    <!-- <p>Now that you know about our Open Source tools, find out about <a href="apps">the applications we have on the market</a>.</p> -->
 
-	<hr class="featurette-divider" id="avocado">
-
-	<div class="row featurette">
-		<div class="col-md-6 order-md-2 order-sm-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/toolbox/squares/square6@1x.jpg 1x, ./assets/img/toolbox/squares/square6@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square6@1x.jpg" alt="0x4447 Avocado" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-1 order-sm-2">
-			<h2 class="featurette-heading hover-link-container">
-				Avocado
-				<a href="#avocado">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">Deploying a simple HTML page that is not build around a framework to AWS CloudFront, is annoying and time consuming. This CLI will build the final page out of a simple folder structure by using the awesome templating engine—Hogan.</p>
-
-			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/avocado"><img width="50" src="./assets/img/_global/npm.svg" alt="npm" /></a>
-			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-avocado"><img width="20" src="./assets/img/_global/github.svg" alt="GitHub" /></a>
-			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-avocado"><img width="20" src="./assets/img/_global/travisci.svg" alt="Travis" /></a>
-		</div>
-	</div>
-
-	<hr class="featurette-divider" id="strawberry">
-
-	<div class="row featurette">
-		<div class="col-md-6 order-md-1">
-			<picture class="featurette-image img-fluid mx-auto">
-				<source srcset="./assets/img/toolbox/squares/square7@1x.jpg 1x, ./assets/img/toolbox/squares/square7@2x.jpg 2x" />
-				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square7@1x.jpg" alt="0x4447 Broccoli" />
-			</picture>
-		</div>
-		<div class="col-md-6 order-md-2">
-			<h2 class="featurette-heading hover-link-container">
-				Strawberry
-				<a href="#strawberry">
-					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-				</a>
-			</h2>
-			<p class="lead">This CLI will automatically create a HTTPS redirect from one domain to another using what AWS has to offer – so you don't have to manage a server for a simple redirect.</p>
-
-			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/strawberry"><img width="50" src="./assets/img/_global/npm.svg" alt="npm" /></a>
-			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-strawberry"><img width="20" src="./assets/img/_global/github.svg" alt="GitHub" /></a>
-			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-strawberry"><img width="20" src="./assets/img/_global/travisci.svg" alt="Travis" /></a>
-		</div>
-	</div>
-
-	<hr class="featurette-divider">
-
-	<h1>The Next Step</h1>
-
-	<!-- <p>Now that you know about our Open Source tools, find out about <a href="apps">the applications we have on the market</a>.</p> -->
-
-	<p>Now that you know all about us, your last step is to <a href="contact.html">get in touch with us</a>.</p>
+    <p>Now that you know all about us, your last step is to <a href="contact.html">get in touch with us</a>.</p>
 
 </div>

--- a/_input/views/toolbox.html
+++ b/_input/views/toolbox.html
@@ -1,233 +1,233 @@
 <div class="container full-screen-container d-flex flex-column justify-content-start justify-content-md-center">
-    <div id="header" class="container">
-        <picture>
-            <source srcset="./assets/img/toolbox/header@1x.jpg 1x, ./assets/img/toolbox/header@2x.jpg 2x" />
-            <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/header@1x.jpg" alt="{{ title }}" />
-            <div class="placeholder-masker">
-                <div class="placeholder-animated-background"></div>
-            </div>
-        </picture>
-    </div>
-    <h1>Our Open-Source Tools</h1>
+	<div id="header" class="container">
+		<picture>
+			<source srcset="./assets/img/toolbox/header@1x.jpg 1x, ./assets/img/toolbox/header@2x.jpg 2x" />
+			<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/header@1x.jpg" alt="{{ title }}" />
+			<div class="placeholder-masker">
+				<div class="placeholder-animated-background"></div>
+			</div>
+		</picture>
+	</div>
+	<h1>Our Open-Source Tools</h1>
 
-    <p>We love to be efficient, but we hate repetitive work! That's why we build tools that help us do the repetitive
-        work
-        for us. It's also why we share them with the world so that others can also benefit. We strongly believe in
-        sharing
-        knowledge in the simplest possible way so other people are able to learn what we already know. Sharing in this
-        way
-        allows us to help people create fresh ideas that will benefit our community.</p>
+	<p>We love to be efficient, but we hate repetitive work! That's why we build tools that help us do the repetitive
+		work
+		for us. It's also why we share them with the world so that others can also benefit. We strongly believe in
+		sharing
+		knowledge in the simplest possible way so other people are able to learn what we already know. Sharing in this
+		way
+		allows us to help people create fresh ideas that will benefit our community.</p>
 </div>
 
 <div class="container marketing">
 
-    <div class="row full-height-row d-flex align-items-center" id="potato">
-        <div class="col-md-6 order-md-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/toolbox/squares/square1@1x.jpg 1x, ./assets/img/toolbox/squares/square1@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square1@1x.jpg" alt="0x4447 Potato" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-2">
-            <h2 class="featurette-heading hover-link-container">
-                Potato
-                <a href="#potato">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">The purpose of 0x4447™'s Potato CLI tool is to streamline the process of hosting a static
-                web page
-                on S3 while using CloudFront to deliver the content.</p>
+	<div class="row full-height-row d-flex align-items-center" id="potato">
+		<div class="col-md-6 order-md-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/toolbox/squares/square1@1x.jpg 1x, ./assets/img/toolbox/squares/square1@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square1@1x.jpg" alt="0x4447 Potato" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-2">
+			<h2 class="featurette-heading hover-link-container">
+				Potato
+				<a href="#potato">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">The purpose of 0x4447™'s Potato CLI tool is to streamline the process of hosting a static
+				web page
+				on S3 while using CloudFront to deliver the content.</p>
 
-            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/potato"><img width="50" src="./assets/img/_global/npm.svg"
-                    alt="npm" /></a>
-            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-potato"><img width="20" src="./assets/img/_global/github.svg"
-                    alt="GitHub" /></a>
-            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-potato"><img width="20" src="./assets/img/_global/travisci.svg"
-                    alt="Travis" /></a>
-        </div>
-    </div>
+			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/potato"><img width="50" src="./assets/img/_global/npm.svg"
+					alt="npm" /></a>
+			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-potato"><img width="20" src="./assets/img/_global/github.svg"
+					alt="GitHub" /></a>
+			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-potato"><img width="20" src="./assets/img/_global/travisci.svg"
+					alt="Travis" /></a>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="tomato">
-        <div class="col-md-6 order-md-2 order-sm-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/toolbox/squares/square2@1x.jpg 1x, ./assets/img/toolbox/squares/square2@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square2@1x.jpg" alt="0x4447 Tomato" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-1 order-sm-2">
-            <h2 class="featurette-heading hover-link-container">
-                Tomato
-                <a href="#tomato">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">This is 0x4447's take on the express-generator CLI that's included with ExpressJS. We
-                created this
-                project because we'd always spend quite a bit of time on bringing the default ExpressJS template up to
-                speed. This
-                was especially true when there was a constant need to spin up new micro-services.</p>
-            <p class="lead">One of this project's nicest features is how simple it is for the user to customize it. If
-                you have
-                your own style, all you need to do is clone the repo and edit the source folder as you like.</p>
+	<div class="row full-height-row d-flex align-items-center" id="tomato">
+		<div class="col-md-6 order-md-2 order-sm-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/toolbox/squares/square2@1x.jpg 1x, ./assets/img/toolbox/squares/square2@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square2@1x.jpg" alt="0x4447 Tomato" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-1 order-sm-2">
+			<h2 class="featurette-heading hover-link-container">
+				Tomato
+				<a href="#tomato">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">This is 0x4447's take on the express-generator CLI that's included with ExpressJS. We
+				created this
+				project because we'd always spend quite a bit of time on bringing the default ExpressJS template up to
+				speed. This
+				was especially true when there was a constant need to spin up new micro-services.</p>
+			<p class="lead">One of this project's nicest features is how simple it is for the user to customize it. If
+				you have
+				your own style, all you need to do is clone the repo and edit the source folder as you like.</p>
 
-            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/tomato"><img width="50" src="./assets/img/_global/npm.svg"
-                    alt="npm" /></a>
-            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-tomato"><img width="20" src="./assets/img/_global/github.svg"
-                    alt="GitHub" /></a>
-            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-tomato"><img width="20" src="./assets/img/_global/travisci.svg"
-                    alt="Travis" /></a>
-        </div>
+			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/tomato"><img width="50" src="./assets/img/_global/npm.svg"
+					alt="npm" /></a>
+			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-tomato"><img width="20" src="./assets/img/_global/github.svg"
+					alt="GitHub" /></a>
+			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-tomato"><img width="20" src="./assets/img/_global/travisci.svg"
+					alt="Travis" /></a>
+		</div>
 
-    </div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="cucumber">
-        <div class="col-md-6 order-md-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/toolbox/squares/square3@1x.jpg 1x, ./assets/img/toolbox/squares/square3@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square3@1x.jpg" alt="0x4447 Cucumber" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-2">
-            <h2 class="featurette-heading hover-link-container">
-                Cucumber
-                <a href="#cucumber">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">Cucumber is a small, simple project that we created to save time as we work with Heroku. It
-                allows
-                us to easily auto-generate the .env file when we develop the project locally.</p>
+	<div class="row full-height-row d-flex align-items-center" id="cucumber">
+		<div class="col-md-6 order-md-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/toolbox/squares/square3@1x.jpg 1x, ./assets/img/toolbox/squares/square3@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square3@1x.jpg" alt="0x4447 Cucumber" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-2">
+			<h2 class="featurette-heading hover-link-container">
+				Cucumber
+				<a href="#cucumber">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">Cucumber is a small, simple project that we created to save time as we work with Heroku. It
+				allows
+				us to easily auto-generate the .env file when we develop the project locally.</p>
 
-            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/cucumber"><img width="50" src="./assets/img/_global/npm.svg"
-                    alt="npm" /></a>
-            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-cucumber"><img width="20" src="./assets/img/_global/github.svg"
-                    alt="GitHub" /></a>
-            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-cucumber"><img width="20" src="./assets/img/_global/travisci.svg"
-                    alt="Travis" /></a>
-        </div>
-    </div>
+			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/cucumber"><img width="50" src="./assets/img/_global/npm.svg"
+					alt="npm" /></a>
+			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-cucumber"><img width="20" src="./assets/img/_global/github.svg"
+					alt="GitHub" /></a>
+			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-cucumber"><img width="20" src="./assets/img/_global/travisci.svg"
+					alt="Travis" /></a>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="hot_pepper">
-        <div class="col-md-6 order-md-2 order-sm-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/toolbox/squares/square4@1x.jpg 1x, ./assets/img/toolbox/squares/square4@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square4@1x.jpg" alt="0x4447 Hot Pepper" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-1 order-sm-2">
-            <h2 class="featurette-heading hover-link-container">
-                Hot Pepper
-                <a href="#hot_pepper">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">This project will save time for those who work with NodeJS projects and prefer to run them
-                on a
-                Linux box using SystemD as the process manager. It creates the SystemD .service file for you, based on
-                the content
-                of the package.json file.</p>
+	<div class="row full-height-row d-flex align-items-center" id="hot_pepper">
+		<div class="col-md-6 order-md-2 order-sm-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/toolbox/squares/square4@1x.jpg 1x, ./assets/img/toolbox/squares/square4@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square4@1x.jpg" alt="0x4447 Hot Pepper" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-1 order-sm-2">
+			<h2 class="featurette-heading hover-link-container">
+				Hot Pepper
+				<a href="#hot_pepper">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">This project will save time for those who work with NodeJS projects and prefer to run them
+				on a
+				Linux box using SystemD as the process manager. It creates the SystemD .service file for you, based on
+				the content
+				of the package.json file.</p>
 
-            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/hotpepper"><img width="50" src="./assets/img/_global/npm.svg"
-                    alt="npm" /></a>
-            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-hot-pepper"><img width="20" src="./assets/img/_global/github.svg"
-                    alt="GitHub" /></a>
-            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-hot-pepper"><img width="20" src="./assets/img/_global/travisci.svg"
-                    alt="Travis" /></a>
-        </div>
-    </div>
+			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/hotpepper"><img width="50" src="./assets/img/_global/npm.svg"
+					alt="npm" /></a>
+			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-hot-pepper"><img width="20" src="./assets/img/_global/github.svg"
+					alt="GitHub" /></a>
+			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-hot-pepper"><img width="20" src="./assets/img/_global/travisci.svg"
+					alt="Travis" /></a>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="broccoli">
-        <div class="col-md-6 order-md-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/toolbox/squares/square5@1x.jpg 1x, ./assets/img/toolbox/squares/square5@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square5@1x.jpg" alt="0x4447 Broccoli" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-2">
-            <h2 class="featurette-heading hover-link-container">
-                Broccoli
-                <a href="#broccoli">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">If you're a developer with a local Nginx setup, and you like to give the sites you work on
-                local
-                domain names, you've experienced the tedium of creating an Nginx config file and restarting Nginx to
-                load the new
-                configuration. This CLI automatically does all of that for you.</p>
+	<div class="row full-height-row d-flex align-items-center" id="broccoli">
+		<div class="col-md-6 order-md-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/toolbox/squares/square5@1x.jpg 1x, ./assets/img/toolbox/squares/square5@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square5@1x.jpg" alt="0x4447 Broccoli" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-2">
+			<h2 class="featurette-heading hover-link-container">
+				Broccoli
+				<a href="#broccoli">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">If you're a developer with a local Nginx setup, and you like to give the sites you work on
+				local
+				domain names, you've experienced the tedium of creating an Nginx config file and restarting Nginx to
+				load the new
+				configuration. This CLI automatically does all of that for you.</p>
 
-            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/broccoli"><img width="50" src="./assets/img/_global/npm.svg"
-                    alt="npm" /></a>
-            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-broccoli"><img width="20" src="./assets/img/_global/github.svg"
-                    alt="GitHub" /></a>
-            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-broccoli"><img width="20" src="./assets/img/_global/travisci.svg"
-                    alt="Travis" /></a>
-        </div>
-    </div>
+			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/broccoli"><img width="50" src="./assets/img/_global/npm.svg"
+					alt="npm" /></a>
+			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-broccoli"><img width="20" src="./assets/img/_global/github.svg"
+					alt="GitHub" /></a>
+			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-broccoli"><img width="20" src="./assets/img/_global/travisci.svg"
+					alt="Travis" /></a>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="avocado">
-        <div class="col-md-6 order-md-2 order-sm-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/toolbox/squares/square6@1x.jpg 1x, ./assets/img/toolbox/squares/square6@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square6@1x.jpg" alt="0x4447 Avocado" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-1 order-sm-2">
-            <h2 class="featurette-heading hover-link-container">
-                Avocado
-                <a href="#avocado">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">Deploying a simple HTML page that is not build around a framework to AWS CloudFront, is
-                annoying and
-                time consuming. This CLI will build the final page out of a simple folder structure by using the
-                awesome templating
-                engine—Hogan.</p>
+	<div class="row full-height-row d-flex align-items-center" id="avocado">
+		<div class="col-md-6 order-md-2 order-sm-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/toolbox/squares/square6@1x.jpg 1x, ./assets/img/toolbox/squares/square6@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square6@1x.jpg" alt="0x4447 Avocado" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-1 order-sm-2">
+			<h2 class="featurette-heading hover-link-container">
+				Avocado
+				<a href="#avocado">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">Deploying a simple HTML page that is not build around a framework to AWS CloudFront, is
+				annoying and
+				time consuming. This CLI will build the final page out of a simple folder structure by using the
+				awesome templating
+				engine—Hogan.</p>
 
-            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/avocado"><img width="50" src="./assets/img/_global/npm.svg"
-                    alt="npm" /></a>
-            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-avocado"><img width="20" src="./assets/img/_global/github.svg"
-                    alt="GitHub" /></a>
-            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-avocado"><img width="20" src="./assets/img/_global/travisci.svg"
-                    alt="Travis" /></a>
-        </div>
-    </div>
+			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/avocado"><img width="50" src="./assets/img/_global/npm.svg"
+					alt="npm" /></a>
+			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-avocado"><img width="20" src="./assets/img/_global/github.svg"
+					alt="GitHub" /></a>
+			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-avocado"><img width="20" src="./assets/img/_global/travisci.svg"
+					alt="Travis" /></a>
+		</div>
+	</div>
 
-    <div class="row full-height-row d-flex align-items-center" id="strawberry">
-        <div class="col-md-6 order-md-1">
-            <picture class="featurette-image img-fluid mx-auto">
-                <source srcset="./assets/img/toolbox/squares/square7@1x.jpg 1x, ./assets/img/toolbox/squares/square7@2x.jpg 2x" />
-                <img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square7@1x.jpg" alt="0x4447 Broccoli" />
-            </picture>
-        </div>
-        <div class="col-md-6 order-md-2">
-            <h2 class="featurette-heading hover-link-container">
-                Strawberry
-                <a href="#strawberry">
-                    <img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
-                </a>
-            </h2>
-            <p class="lead">This CLI will automatically create a HTTPS redirect from one domain to another using what
-                AWS has to
-                offer – so you don't have to manage a server for a simple redirect.</p>
+	<div class="row full-height-row d-flex align-items-center" id="strawberry">
+		<div class="col-md-6 order-md-1">
+			<picture class="featurette-image img-fluid mx-auto">
+				<source srcset="./assets/img/toolbox/squares/square7@1x.jpg 1x, ./assets/img/toolbox/squares/square7@2x.jpg 2x" />
+				<img class="featurette-image img-fluid mx-auto" src="./assets/img/toolbox/squares/square7@1x.jpg" alt="0x4447 Broccoli" />
+			</picture>
+		</div>
+		<div class="col-md-6 order-md-2">
+			<h2 class="featurette-heading hover-link-container">
+				Strawberry
+				<a href="#strawberry">
+					<img src="./assets/img/_global/baseline-link.svg" alt="Link Icon" />
+				</a>
+			</h2>
+			<p class="lead">This CLI will automatically create a HTTPS redirect from one domain to another using what
+				AWS has to
+				offer – so you don't have to manage a server for a simple redirect.</p>
 
-            <a target="_blank" href="https://www.npmjs.com/package/@0x4447/strawberry"><img width="50" src="./assets/img/_global/npm.svg"
-                    alt="npm" /></a>
-            <a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-strawberry"><img width="20" src="./assets/img/_global/github.svg"
-                    alt="GitHub" /></a>
-            <a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-strawberry"><img width="20" src="./assets/img/_global/travisci.svg"
-                    alt="Travis" /></a>
-        </div>
-    </div>
+			<a target="_blank" href="https://www.npmjs.com/package/@0x4447/strawberry"><img width="50" src="./assets/img/_global/npm.svg"
+					alt="npm" /></a>
+			<a target="_blank" href="https://github.com/0x4447/0x4447-cli-node-strawberry"><img width="20" src="./assets/img/_global/github.svg"
+					alt="GitHub" /></a>
+			<a target="_blank" href="https://travis-ci.org/0x4447/0x4447-cli-node-strawberry"><img width="20" src="./assets/img/_global/travisci.svg"
+					alt="Travis" /></a>
+		</div>
+	</div>
 
-    <hr class="featurette-divider">
+	<hr class="featurette-divider">
 
-    <h1>The Next Step</h1>
+	<h1>The Next Step</h1>
 
-    <!-- <p>Now that you know about our Open Source tools, find out about <a href="apps">the applications we have on the market</a>.</p> -->
+	<!-- <p>Now that you know about our Open Source tools, find out about <a href="apps">the applications we have on the market</a>.</p> -->
 
-    <p>Now that you know all about us, your last step is to <a href="contact.html">get in touch with us</a>.</p>
+	<p>Now that you know all about us, your last step is to <a href="contact.html">get in touch with us</a>.</p>
 
 </div>


### PR DESCRIPTION
### Acknowledgments

- [ ] I confirm that I wrote the code based on the [company guidelines](https://github.com/0x4447/0x4447-Foundation/tree/master/programmer#coding-principles).
- [ ] I confirm that I followed the Git flow described in the [company guidelines](https://github.com/0x4447/0x4447-Foundation/tree/master/programmer#how-to-work-with-github).

### Description

Changed the rows of the anchors to be the full height of the screen and removed the featurette divider, which was originally setting them apart with a margin. By doing this, we get each anchor section to be full screen on most screen sizes except phones, where the content will stretch the `div`.

Also, I minorly adjusted the size of the `vh` for the containers used at the top of full height containers.

Since we no longer needed the dividers, I removed them and attached the `id` to the `row` containing the anchor. Also, on mobile, I made sure to set a margin on the rows to keep them apart from each other a little bit.

Issue(s): #58 